### PR TITLE
Feat/notificatrions UI

### DIFF
--- a/src/components/molecules/authenticated-top-bar.tsx
+++ b/src/components/molecules/authenticated-top-bar.tsx
@@ -2,8 +2,14 @@
 
 import { usePathname } from "next/navigation";
 import { SalinaLogo } from "@/components/atoms/salina-logo";
-import { cn } from "@/lib/utils";
 import type { UserRole } from "@/lib/navigation-config";
+import { NotificationBell } from "@/components/organisms/notification-bell";
+import {
+  superAdminNotifications,
+  adminNotifications,
+  officerNotifications,
+  memberNotifications
+} from "@/lib/notification-data";
 
 export interface AuthenticatedTenantBranding {
   name: string;
@@ -30,9 +36,7 @@ function getInitials(name: string) {
   );
 }
 
-export function AuthenticatedTopBar({
-  role,
-  tenantBranding,
+export function AuthenticatedTopBar({ role, tenantBranding,
   userName = "Jane Doe",
 }: AuthenticatedTopBarProps) {
   const pathname = usePathname() || "";
@@ -64,10 +68,10 @@ export function AuthenticatedTopBar({
     roleSegment === "officer" && lastSegment === "members"
       ? "Roster"
       : ROUTE_TITLES[lastSegment] ||
-        lastSegment
-          .split("-")
-          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-          .join(" ");
+      lastSegment
+        .split("-")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
 
   return (
     <header className="sticky top-0 z-30 flex h-20 shrink-0 items-center justify-between gap-4 border-b border-slate-200 bg-white/95 px-6 shadow-sm backdrop-blur sm:px-8">
@@ -112,24 +116,14 @@ export function AuthenticatedTopBar({
       </div>
 
       <div className="flex items-center gap-3">
-        <button
-          type="button"
-          className={cn(
-            "relative flex h-10 w-10 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 shadow-sm transition-colors",
-            "hover:bg-slate-50 hover:text-slate-700",
-          )}
-          aria-label="Notifications"
-        >
-          <svg width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-            />
-          </svg>
-          <span className="absolute right-2 top-2 h-2 w-2 rounded-full border border-white bg-rose-500" />
-        </button>
+        <NotificationBell
+          initialNotifications={
+            role === "SuperAdmin" ? superAdminNotifications :
+              role === "Admin" ? adminNotifications :
+                role === "Officer" ? officerNotifications :
+                  memberNotifications
+          }
+        />
 
         <button
           type="button"

--- a/src/components/molecules/notification-item.tsx
+++ b/src/components/molecules/notification-item.tsx
@@ -1,0 +1,57 @@
+import { cn } from "@/lib/utils";
+import { NotificationData } from "@/lib/notification-data";
+
+interface NotificationItemProps {
+    notification: NotificationData;
+    onClick?: (id: string) => void;
+}
+
+export function NotificationItem({ notification, onClick }: NotificationItemProps) {
+    // Dynamically assign an icon and color based on the type of notification
+    const getIcon = () => {
+        switch (notification.type) {
+            case 'event': // Green calendar/check
+                return <svg className="w-4 h-4 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>;
+            case 'system': // Blue gear/settings
+                return <svg className="w-4 h-4 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>;
+            case 'message': // Purple chat bubble
+                return <svg className="w-4 h-4 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" /></svg>;
+            case 'alert': // Yellow warning
+            default:
+                return <svg className="w-4 h-4 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>;
+        }
+    };
+
+    return (
+        <button
+            onClick={() => onClick && onClick(notification.id)}
+            className={cn(
+                "w-full text-left flex gap-3 p-4 hover:bg-slate-50 transition-colors border-b border-slate-100 last:border-0",
+                !notification.isRead && "bg-slate-50/50"
+            )}
+        >
+            <div className="shrink-0 mt-0.5">
+                <div className="w-8 h-8 rounded-full bg-white border border-slate-200 flex items-center justify-center shadow-sm">
+                    {getIcon()}
+                </div>
+            </div>
+            <div className="flex-1 min-w-0">
+                <p className={cn("text-sm truncate", notification.isRead ? "font-medium text-slate-700" : "font-bold text-slate-900")}>
+                    {notification.title}
+                </p>
+                <p className="text-xs text-slate-500 mt-1 line-clamp-2 leading-relaxed">
+                    {notification.message}
+                </p>
+                <p className="text-[10px] font-bold text-slate-400 mt-2 uppercase tracking-wider">
+                    {notification.time}
+                </p>
+            </div>
+            {/* The Unread Blue Dot indicator */}
+            {!notification.isRead && (
+                <div className="shrink-0 flex items-center">
+                    <span className="w-2 h-2 rounded-full bg-blue-500 shadow-sm" />
+                </div>
+            )}
+        </button>
+    );
+}

--- a/src/components/organisms/notification-bell.tsx
+++ b/src/components/organisms/notification-bell.tsx
@@ -16,7 +16,6 @@ export function NotificationBell({ initialNotifications }: NotificationBellProps
     // Calculate how many unread notifications we have
     const unreadCount = notifications.filter(n => !n.isRead).length;
 
-    // Handle clicking outside the dropdown to close it
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
             if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {

--- a/src/components/organisms/notification-bell.tsx
+++ b/src/components/organisms/notification-bell.tsx
@@ -1,107 +1,135 @@
-'use client';
+"use client";
 
-import { useState, useRef, useEffect } from "react";
-import { NotificationData } from "@/lib/notification-data";
+import { useId, useState } from "react";
+
 import { NotificationItem } from "@/components/molecules/notification-item";
+import { NotificationData } from "@/lib/notification-data";
 
 interface NotificationBellProps {
-    initialNotifications: NotificationData[];
+  initialNotifications: NotificationData[];
 }
 
-export function NotificationBell({ initialNotifications }: NotificationBellProps) {
-    const [isOpen, setIsOpen] = useState(false);
-    const [notifications, setNotifications] = useState(initialNotifications);
-    const dropdownRef = useRef<HTMLDivElement>(null);
+export function NotificationBell({
+  initialNotifications,
+}: NotificationBellProps) {
+  const [notifications, setNotifications] = useState(initialNotifications);
+  const toggleId = useId();
 
-    // Calculate how many unread notifications we have
-    const unreadCount = notifications.filter(n => !n.isRead).length;
+  // Calculate how many unread notifications we have
+  const unreadCount = notifications.filter(
+    (notification) => !notification.isRead,
+  ).length;
 
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-            }
-        };
-        document.addEventListener("mousedown", handleClickOutside);
-        return () => document.removeEventListener("mousedown", handleClickOutside);
-    }, []);
-
-    // Mark a single notification as read when clicked
-    const handleNotificationClick = (id: string) => {
-        setNotifications(prev =>
-            prev.map(n => n.id === id ? { ...n, isRead: true } : n)
-        );
-    };
-
-    // Mark all as read
-    const handleMarkAllRead = (e: React.MouseEvent) => {
-        e.stopPropagation(); // Prevent dropdown from closing
-        setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
-    };
-
-    return (
-        <div className="relative" ref={dropdownRef}>
-            {/* The Bell Button */}
-            <button
-                onClick={() => setIsOpen(!isOpen)}
-                className="relative p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-full hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200"
-            >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-                </svg>
-
-                {/* Red Unread Badge */}
-                {unreadCount > 0 && (
-                    <span className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-rose-500 border-2 border-white rounded-full" />
-                )}
-            </button>
-
-            {/* The Dropdown Panel */}
-            {isOpen && (
-                <div className="absolute right-0 mt-2 w-[320px] sm:w-[380px] bg-white border border-slate-200 rounded-2xl shadow-xl overflow-hidden z-50 animate-in fade-in slide-in-from-top-2 duration-200">
-
-                    {/* Header */}
-                    <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between bg-slate-50/80 backdrop-blur-sm">
-                        <div className="flex items-center gap-2">
-                            <h3 className="font-bold text-slate-800">Notifications</h3>
-                            {unreadCount > 0 && (
-                                <span className="bg-blue-100 text-blue-700 text-[10px] font-bold px-2 py-0.5 rounded-full">
-                                    {unreadCount} New
-                                </span>
-                            )}
-                        </div>
-                        {unreadCount > 0 && (
-                            <button
-                                onClick={handleMarkAllRead}
-                                className="text-xs font-semibold text-blue-600 hover:text-blue-800 transition-colors"
-                            >
-                                Mark all as read
-                            </button>
-                        )}
-                    </div>
-
-                    {/* Scrollable List */}
-                    <div className="max-h-[380px] overflow-y-auto custom-scrollbar">
-                        {notifications.length > 0 ? (
-                            notifications.map(notif => (
-                                <NotificationItem
-                                    key={notif.id}
-                                    notification={notif}
-                                    onClick={handleNotificationClick}
-                                />
-                            ))
-                        ) : (
-                            <div className="p-8 flex flex-col items-center text-center text-slate-500">
-                                <div className="w-12 h-12 bg-slate-50 rounded-full flex items-center justify-center mb-3">
-                                    <svg className="w-6 h-6 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" /></svg>
-                                </div>
-                                <p className="text-sm font-medium text-slate-800">You&apos;re all caught up!</p>
-                                <p className="text-xs mt-1">No new notifications right now.</p>
-                            </div>
-                        )}
-                    </div>
-                </div>
-            )}
-        </div>
+  // Mark a single notification as read when clicked
+  const handleNotificationClick = (id: string) => {
+    setNotifications((prev) =>
+      prev.map((notification) =>
+        notification.id === id
+          ? { ...notification, isRead: true }
+          : notification,
+      ),
     );
+  };
+
+  // Mark all as read
+  const handleMarkAllRead = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setNotifications((prev) =>
+      prev.map((notification) => ({ ...notification, isRead: true })),
+    );
+  };
+
+  return (
+    <div className="relative">
+      <input
+        id={toggleId}
+        type="checkbox"
+        className="peer sr-only"
+        aria-label="Toggle notifications"
+      />
+
+      {/* The Bell Button */}
+      <label
+        htmlFor={toggleId}
+        className="relative flex cursor-pointer items-center justify-center rounded-full p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-slate-200 peer-focus-visible:ring-2 peer-focus-visible:ring-slate-200"
+      >
+        <svg
+          className="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          />
+        </svg>
+
+        {/* Red Unread Badge */}
+        {unreadCount > 0 && (
+          <span className="absolute right-1.5 top-1.5 h-2.5 w-2.5 rounded-full border-2 border-white bg-rose-500" />
+        )}
+      </label>
+
+      {/* The Dropdown Panel */}
+      <div className="absolute right-0 top-full z-50 mt-2 hidden w-[320px] overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl animate-in fade-in slide-in-from-top-2 duration-200 peer-checked:block sm:w-95">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50/80 px-4 py-3 backdrop-blur-sm">
+          <div className="flex items-center gap-2">
+            <h3 className="font-bold text-slate-800">Notifications</h3>
+            {unreadCount > 0 && (
+              <span className="rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold text-blue-700">
+                {unreadCount} New
+              </span>
+            )}
+          </div>
+          {unreadCount > 0 && (
+            <button
+              onClick={handleMarkAllRead}
+              className="text-xs font-semibold text-blue-600 transition-colors hover:text-blue-800"
+            >
+              Mark all as read
+            </button>
+          )}
+        </div>
+
+        {/* Scrollable List */}
+        <div className="max-h-95 overflow-y-auto custom-scrollbar">
+          {notifications.length > 0 ? (
+            notifications.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onClick={handleNotificationClick}
+              />
+            ))
+          ) : (
+            <div className="flex flex-col items-center p-8 text-center text-slate-500">
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-50">
+                <svg
+                  className="h-6 w-6 text-slate-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"
+                  />
+                </svg>
+              </div>
+              <p className="text-sm font-medium text-slate-800">
+                You&apos;re all caught up!
+              </p>
+              <p className="mt-1 text-xs">No new notifications right now.</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/organisms/notification-bell.tsx
+++ b/src/components/organisms/notification-bell.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useRef, useEffect } from "react";
+import { NotificationData } from "@/lib/notification-data";
+import { NotificationItem } from "@/components/molecules/notification-item";
+
+interface NotificationBellProps {
+    initialNotifications: NotificationData[];
+}
+
+export function NotificationBell({ initialNotifications }: NotificationBellProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [notifications, setNotifications] = useState(initialNotifications);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    // Calculate how many unread notifications we have
+    const unreadCount = notifications.filter(n => !n.isRead).length;
+
+    // Handle clicking outside the dropdown to close it
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+    // Mark a single notification as read when clicked
+    const handleNotificationClick = (id: string) => {
+        setNotifications(prev =>
+            prev.map(n => n.id === id ? { ...n, isRead: true } : n)
+        );
+    };
+
+    // Mark all as read
+    const handleMarkAllRead = (e: React.MouseEvent) => {
+        e.stopPropagation(); // Prevent dropdown from closing
+        setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
+    };
+
+    return (
+        <div className="relative" ref={dropdownRef}>
+            {/* The Bell Button */}
+            <button
+                onClick={() => setIsOpen(!isOpen)}
+                className="relative p-2 text-slate-400 hover:text-slate-600 transition-colors rounded-full hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-200"
+            >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+                </svg>
+
+                {/* Red Unread Badge */}
+                {unreadCount > 0 && (
+                    <span className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-rose-500 border-2 border-white rounded-full" />
+                )}
+            </button>
+
+            {/* The Dropdown Panel */}
+            {isOpen && (
+                <div className="absolute right-0 mt-2 w-[320px] sm:w-[380px] bg-white border border-slate-200 rounded-2xl shadow-xl overflow-hidden z-50 animate-in fade-in slide-in-from-top-2 duration-200">
+
+                    {/* Header */}
+                    <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between bg-slate-50/80 backdrop-blur-sm">
+                        <div className="flex items-center gap-2">
+                            <h3 className="font-bold text-slate-800">Notifications</h3>
+                            {unreadCount > 0 && (
+                                <span className="bg-blue-100 text-blue-700 text-[10px] font-bold px-2 py-0.5 rounded-full">
+                                    {unreadCount} New
+                                </span>
+                            )}
+                        </div>
+                        {unreadCount > 0 && (
+                            <button
+                                onClick={handleMarkAllRead}
+                                className="text-xs font-semibold text-blue-600 hover:text-blue-800 transition-colors"
+                            >
+                                Mark all as read
+                            </button>
+                        )}
+                    </div>
+
+                    {/* Scrollable List */}
+                    <div className="max-h-[380px] overflow-y-auto custom-scrollbar">
+                        {notifications.length > 0 ? (
+                            notifications.map(notif => (
+                                <NotificationItem
+                                    key={notif.id}
+                                    notification={notif}
+                                    onClick={handleNotificationClick}
+                                />
+                            ))
+                        ) : (
+                            <div className="p-8 flex flex-col items-center text-center text-slate-500">
+                                <div className="w-12 h-12 bg-slate-50 rounded-full flex items-center justify-center mb-3">
+                                    <svg className="w-6 h-6 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" /></svg>
+                                </div>
+                                <p className="text-sm font-medium text-slate-800">You&apos;re all caught up!</p>
+                                <p className="text-xs mt-1">No new notifications right now.</p>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/templates/authenticated-shell.tsx
+++ b/src/components/templates/authenticated-shell.tsx
@@ -53,23 +53,20 @@ export function AuthenticatedShell({
   userName,
 }: AuthenticatedShellProps) {
   return (
-    <div
-      className="flex min-h-screen w-full items-start bg-slate-50"
-      style={{ fontFamily: "var(--font-body)" }}
-    >
+    <div className="flex w-full h-dvh overflow-hidden bg-slate-50">
       <SidebarNav role={role} tenant={tenantBranding} userName={userName} />
 
-      <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+      <main className="flex-1 h-full overflow-y-auto relative flex flex-col">
         <AuthenticatedTopBar
           role={role}
           tenantBranding={tenantBranding}
           userName={userName}
         />
 
-        <main className="flex-1 p-6 sm:p-8">
+        <div className="flex-1 p-6 lg:p-8">
           {children ?? emptyState ?? <ShellEmptyState role={role} />}
-        </main>
-      </div>
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/lib/notification-data.ts
+++ b/src/lib/notification-data.ts
@@ -9,6 +9,25 @@ export interface NotificationData {
   isRead: boolean;
 }
 
+/**
+ * ============================================================================
+ * NOTE - NOTIFICATION TRIGGERS
+ * ============================================================================
+ *
+ * The arrays below contain DUMMY DATA for frontend UI testing.
+ *
+ * As backend features (Events, Applications, Announcements) are completed,
+ * replace these static arrays with real Supabase fetches or realtime subscriptions.
+ *
+ * Recommended future trigger mapping:
+ * - Super Admin: New Organization Registrations, System Alerts, Global Bans
+ * - Admin: New Member Signups, Officer Role Changes, Payment Receipts, Accreditation Status Updates
+ * - Officer: New RSVPs to Events, Attendance Thresholds, Document Approvals
+ * - Member: Upcoming Events, Announcement Posts, Application Status Changes
+ *
+ * ============================================================================
+ */
+
 export const superAdminNotifications: NotificationData[] = [
   {
     id: "sa1",

--- a/src/lib/notification-data.ts
+++ b/src/lib/notification-data.ts
@@ -1,0 +1,92 @@
+export type NotificationType = "alert" | "event" | "system" | "message";
+
+export interface NotificationData {
+  id: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  time: string;
+  isRead: boolean;
+}
+
+export const superAdminNotifications: NotificationData[] = [
+  {
+    id: "sa1",
+    type: "system",
+    title: "Pending Accreditation",
+    message:
+      "You have a pending accreditation request from [Org Name]. Please review their submitted documents.",
+    time: "10 mins ago",
+    isRead: false,
+  },
+  {
+    id: "sa2",
+    type: "alert",
+    title: "System Maintenance",
+    message:
+      "Salina servers will undergo brief maintenance on Sunday at 2:00 AM.",
+    time: "2 hours ago",
+    isRead: true,
+  },
+];
+
+export const adminNotifications: NotificationData[] = [
+  {
+    id: "a1",
+    type: "message",
+    title: "New Announcement",
+    message:
+      "Kirk (Vice President) posted a new announcement to the general feed.",
+    time: "Just now",
+    isRead: false,
+  },
+  {
+    id: "a2",
+    type: "system",
+    title: "Roster Updated",
+    message: "3 new members have successfully completed their onboarding.",
+    time: "1 day ago",
+    isRead: true,
+  },
+];
+
+export const officerNotifications: NotificationData[] = [
+  {
+    id: "o1",
+    type: "event",
+    title: "Event Reminder",
+    message:
+      "Bytes & Boards is happening tomorrow! Don't forget to prepare the attendance scanner.",
+    time: "1 hour ago",
+    isRead: false,
+  },
+  {
+    id: "o2",
+    type: "message",
+    title: "New RSVP",
+    message: "5 more members just RSVP'd to your upcoming event.",
+    time: "3 hours ago",
+    isRead: true,
+  },
+];
+
+export const memberNotifications: NotificationData[] = [
+  {
+    id: "m1",
+    type: "event",
+    title: "Event Starting Now!",
+    message:
+      "Region 7 CpE Challenge is happening right now! Don't forget to scan your ID for attendance.",
+    time: "Just now",
+    isRead: false,
+  },
+  {
+    id: "m2",
+    type: "alert",
+    title: "Membership Approved",
+    message:
+      "Welcome to the organization! Your membership status is now active.",
+    time: "Yesterday",
+    isRead: true,
+  },
+];


### PR DESCRIPTION
## Description
Implemented a universal, role-based notification UI using Atomic Design principles. The notification bell and dropdown now adapt dynamically based on the logged-in user's role (`SuperAdmin`, `Admin`, `Officer`, `Member`).

## Changes Made
* **Molecule (`NotificationItem`)**: Created a reusable row component that renders dynamic icons, colors, and unread indicators based on the notification type (`alert`, `event`, `system`, `message`).
* **Organism (`NotificationBell`)**: Built the interactive bell dropdown featuring an unread counter badge, "Mark all as read" functionality, and click-away-to-close behavior.
* **Data (`notification-data.ts`)**: Added structured dummy data arrays for all four user roles to support frontend testing and layout validation.
* **Integration**: Wired the `NotificationBell` into the `AuthenticatedTopBar` to conditionally pass the correct notification array based on the `role` prop.

## Developer Note for Backend/Fullstack
Currently, the notification dropdown is populated using **dummy data** from `src/lib/notification-data.ts` for UI/UX testing. 
* When hooking this up to the database (Supabase), please replace these static arrays with real fetches or realtime triggers or subscriptons.
* Feel free to add more event triggers or types to the data arrays as you build out the backend logic.


<img width="606" height="433" alt="Screenshot 2026-05-02 165208" src="https://github.com/user-attachments/assets/b65c58db-e061-442a-8ff4-a384a55a8123" />
<img width="642" height="417" alt="Screenshot 2026-05-02 165224" src="https://github.com/user-attachments/assets/70a44b44-8e04-4647-b00d-2e7717c9aa62" />
