### PR TITLE
feat: implement admin org recruitment tab

### DIFF
--- a/src/app/admin/recruitment/[entryId]/error.tsx
+++ b/src/app/admin/recruitment/[entryId]/error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Button } from "@/components/atoms/button";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function ErrorBoundary({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Recruitment entries failed to load:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center p-12 text-center" style={{ fontFamily: "var(--font-body)" }}>
+      <div className="mb-6 rounded-full bg-red-100 p-4">
+        <svg
+          className="h-8 w-8 text-red-600"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      </div>
+      <h2 
+        className="mb-2 text-2xl font-bold text-foreground"
+        style={{ fontFamily: 'var(--font-heading)' }}
+      >
+        Something went wrong
+      </h2>
+      <p className="mb-6 text-slate-600">
+        We encountered an error while loading the applicants for this pipeline.
+      </p>
+      <div className="flex gap-4">
+        <Button onClick={() => reset()} variant="secondary">
+          Try again
+        </Button>
+        <Link href="/admin/recruitment" className="inline-flex h-10 items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800">
+          Back to Recruitment
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/recruitment/[entryId]/page.tsx
+++ b/src/app/admin/recruitment/[entryId]/page.tsx
@@ -1,5 +1,4 @@
-import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
-import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { resolveCurrentTenant, getCurrentViewer, createSupabaseUserClient } from "@/lib/supabase/server";
 import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
 import { redirect } from "next/navigation";
 import { ApplicationBoard } from "@/components/organisms/application-board";
@@ -12,14 +11,14 @@ export default async function RecruitmentEntryPage({
   const { entryId } = await params;
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("recruitment-entry");
+  const userClient = await createSupabaseUserClient();
 
-  if (!tenant || !adminClient || !canManageTemporaryApplicants(viewer)) {
+  if (!tenant || !userClient || !viewer || !canManageTemporaryApplicants(viewer)) {
     redirect("/admin/dashboard");
   }
 
   // Double check entry exists
-  const { data: entry, error: entryErr } = await adminClient
+  const { data: entry, error: entryErr } = await userClient
     .from("recruitment_entries")
     .select("title")
     .eq("id", entryId)
@@ -31,7 +30,7 @@ export default async function RecruitmentEntryPage({
   }
 
   // Retrieve temporary_applicants with this entry
-  const { data: applicantsRaw, error: applicantsErr } = await adminClient
+  const { data: applicantsRaw, error: applicantsErr } = await userClient
     .from("temporary_applicants")
     .select(
       "id, applicant_name, applicant_email, status, created_at, application_data",

--- a/src/app/admin/recruitment/[entryId]/page.tsx
+++ b/src/app/admin/recruitment/[entryId]/page.tsx
@@ -1,0 +1,56 @@
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
+import { redirect } from "next/navigation";
+import { ApplicationBoard } from "@/components/organisms/application-board";
+
+export default async function RecruitmentEntryPage({
+  params,
+}: {
+  params: Promise<{ entryId: string }>;
+}) {
+  const { entryId } = await params;
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("recruitment-entry");
+
+  if (!tenant || !adminClient || !canManageTemporaryApplicants(viewer)) {
+    redirect("/admin/dashboard");
+  }
+
+  // Double check entry exists
+  const { data: entry, error: entryErr } = await adminClient
+    .from("recruitment_entries")
+    .select("title")
+    .eq("id", entryId)
+    .eq("tenant_id", tenant.id)
+    .single();
+
+  if (entryErr || !entry) {
+    redirect("/admin/recruitment");
+  }
+
+  // Retrieve temporary_applicants with this entry
+  const { data: applicantsRaw, error: applicantsErr } = await adminClient
+    .from("temporary_applicants")
+    .select(
+      "id, applicant_name, applicant_email, status, created_at, application_data",
+    )
+    .eq("recruitment_entry_id", entryId)
+    .eq("tenant_id", tenant.id);
+
+  if (applicantsErr) {
+    throw applicantsErr;
+  }
+
+  const applicants = (applicantsRaw || []).map((a) => ({
+    id: a.id,
+    name: a.applicant_name,
+    email: a.applicant_email,
+    status: a.status,
+    created_at: a.created_at,
+    stage: (a.application_data as { stage?: string })?.stage || "application",
+  }));
+
+  return <ApplicationBoard entryTitle={entry.title} applicants={applicants} />;
+}

--- a/src/app/admin/recruitment/page.tsx
+++ b/src/app/admin/recruitment/page.tsx
@@ -1,5 +1,4 @@
-import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
-import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { resolveCurrentTenant, getCurrentViewer, createSupabaseUserClient } from "@/lib/supabase/server";
 import { RecruitmentList } from "@/components/organisms/recruitment-list";
 import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
 import { redirect } from "next/navigation";
@@ -7,13 +6,13 @@ import { redirect } from "next/navigation";
 export default async function RecruitmentIndexPage() {
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("recruitment-list");
+  const userClient = await createSupabaseUserClient();
 
-  if (!tenant || !adminClient || !canManageTemporaryApplicants(viewer)) {
+  if (!tenant || !userClient || !viewer || !canManageTemporaryApplicants(viewer)) {
     redirect("/admin/dashboard");
   }
 
-  const { data: entries, error } = await adminClient
+  const { data: entries, error } = await userClient
     .from("recruitment_entries")
     .select("id, title, description, status, created_at")
     .eq("tenant_id", tenant.id)

--- a/src/app/admin/recruitment/page.tsx
+++ b/src/app/admin/recruitment/page.tsx
@@ -1,194 +1,27 @@
-'use client';
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { RecruitmentList } from "@/components/organisms/recruitment-list";
+import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
+import { redirect } from "next/navigation";
 
-import { useState } from 'react';
-import { Button } from '@/components/atoms/button';
+export default async function RecruitmentIndexPage() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("recruitment-list");
 
-interface Applicant {
-    initials: string;
-    name: string;
-    email: string;
-    date: string;
-    stage: string;
-    pillClass: string;
-    pillLabel: string;
-}
+  if (!tenant || !adminClient || !canManageTemporaryApplicants(viewer)) {
+    redirect("/admin/dashboard");
+  }
 
-const COLUMNS: { id: string; label: string; applicants: Applicant[] }[] = [
-    {
-        id: 'application',
-        label: 'Application',
-        applicants: [
-            { initials: 'JD', name: 'Jane Doe',   email: 'jane@email.com',  date: 'Applied Apr 20',      stage: 'Application',  pillClass: 'bg-primary/10 text-primary border-primary/30',    pillLabel: 'New'        },
-            { initials: 'MS', name: 'Mike Smith',  email: 'mike@email.com',  date: 'Applied Apr 21',      stage: 'Application',  pillClass: 'bg-primary/10 text-primary border-primary/30',    pillLabel: 'New'        },
-            { initials: 'LC', name: 'Lisa Chen',   email: 'lisa@email.com',  date: 'Applied Apr 22',      stage: 'Application',  pillClass: 'bg-primary/10 text-primary border-primary/30',    pillLabel: 'New'        },
-        ],
-    },
-    {
-        id: 'screening',
-        label: 'Screening',
-        applicants: [
-            { initials: 'RK', name: 'Ryan Kim',   email: 'ryan@email.com',  date: 'Screened Apr 18',     stage: 'Screening',    pillClass: 'bg-warning/10 text-warning border-warning/30',    pillLabel: 'In Review'  },
-            { initials: 'AP', name: 'Amy Park',   email: 'amy@email.com',   date: 'Screened Apr 19',     stage: 'Screening',    pillClass: 'bg-warning/10 text-warning border-warning/30',    pillLabel: 'In Review'  },
-        ],
-    },
-    {
-        id: 'interview',
-        label: 'Interview',
-        applicants: [
-            { initials: 'BJ', name: 'Bob Jones',  email: 'bob@email.com',   date: 'Interview Apr 15',    stage: 'Interview',    pillClass: 'bg-accent/10 text-accent border-accent/30',       pillLabel: 'Scheduled'  },
-            { initials: 'SW', name: 'Sara White',  email: 'sara@email.com',  date: 'Interview Apr 16',    stage: 'Interview',    pillClass: 'bg-accent/10 text-accent border-accent/30',       pillLabel: 'Scheduled'  },
-        ],
-    },
-    {
-        id: 'deliberation',
-        label: 'Deliberation',
-        applicants: [
-            { initials: 'TL', name: 'Tom Lee',    email: 'tom@email.com',   date: 'Final Review Apr 10', stage: 'Deliberation', pillClass: 'bg-success/10 text-success border-success/30',    pillLabel: 'Final'      },
-        ],
-    },
-];
+  const { data: entries, error } = await adminClient
+    .from("recruitment_entries")
+    .select("id, title, description, status, created_at")
+    .eq("tenant_id", tenant.id)
+    .order("created_at", { ascending: false });
 
-const MOCK_DOCS = ['Resume.pdf', 'Cover Letter.pdf', 'ID Document.pdf'];
+  if (error) {
+    throw error;
+  }
 
-export default function RecruitmentPage() {
-    const [selectedApplicant, setSelectedApplicant] = useState<Applicant | null>(null);
-
-    return (
-        <div
-            className="flex -m-6 sm:-m-8 min-h-[calc(100vh-4rem)]"
-            style={{ fontFamily: 'var(--font-body)' }}
-        >
-            {/* Kanban area */}
-            <div className="min-w-0 flex-1 overflow-y-auto p-6 sm:p-8">
-                {/* Header */}
-                <div className="mb-6 flex items-center justify-between">
-                    <h1
-                        className="text-3xl font-bold tracking-tight text-foreground"
-                        style={{ fontFamily: 'var(--font-heading)' }}
-                    >
-                        Recruitment Pipeline
-                    </h1>
-                    <Button>+ New Stage</Button>
-                </div>
-
-                {/* Columns */}
-                <div className="grid grid-cols-4 gap-4">
-                    {COLUMNS.map((col) => (
-                        <div
-                            key={col.id}
-                            className="min-h-[500px] rounded-2xl border border-border bg-slate-50 p-4"
-                        >
-                            {/* Column header */}
-                            <div className="mb-4 flex items-center justify-between">
-                                <span className="text-sm font-semibold text-foreground">
-                                    {col.label}
-                                </span>
-                                <span className="rounded-full border border-border bg-white px-2 py-0.5 text-xs text-slate-500">
-                                    {col.applicants.length}
-                                </span>
-                            </div>
-
-                            {/* Cards */}
-                            {col.applicants.map((applicant) => (
-                                <div
-                                    key={applicant.email}
-                                    onClick={() => setSelectedApplicant(
-                                        selectedApplicant?.email === applicant.email ? null : applicant
-                                    )}
-                                    className="mb-3 cursor-pointer rounded-xl border border-border bg-white p-4 shadow-sm transition-colors hover:border-primary/30"
-                                >
-                                    <div className="mb-2 flex items-center gap-2">
-                                        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
-                                            {applicant.initials}
-                                        </div>
-                                        <span className="text-sm font-semibold text-foreground">
-                                            {applicant.name}
-                                        </span>
-                                    </div>
-                                    <p className="mb-2 text-xs text-slate-500">{applicant.date}</p>
-                                    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${applicant.pillClass}`}>
-                                        {applicant.pillLabel}
-                                    </span>
-                                </div>
-                            ))}
-                        </div>
-                    ))}
-                </div>
-            </div>
-
-            {/* Detail panel */}
-            {selectedApplicant && (
-                <aside className="flex w-80 shrink-0 flex-col overflow-y-auto border-l border-border bg-white p-6">
-                    {/* Close */}
-                    <button
-                        type="button"
-                        onClick={() => setSelectedApplicant(null)}
-                        className="mb-4 self-end text-xs text-slate-400 transition-colors hover:text-foreground"
-                    >
-                        ✕ Close
-                    </button>
-
-                    {/* Avatar + name */}
-                    <div className="mb-6 flex flex-col items-center text-center">
-                        <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-lg font-bold text-primary">
-                            {selectedApplicant.initials}
-                        </div>
-                        <h2
-                            className="text-lg font-bold text-foreground"
-                            style={{ fontFamily: 'var(--font-heading)' }}
-                        >
-                            {selectedApplicant.name}
-                        </h2>
-                        <p className="mt-0.5 text-xs text-slate-500">{selectedApplicant.email}</p>
-                    </div>
-
-                    {/* Details */}
-                    <div className="mb-6 space-y-3 rounded-xl border border-border p-4">
-                        <div>
-                            <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                                Applied
-                            </p>
-                            <p className="mt-0.5 text-sm text-foreground">{selectedApplicant.date}</p>
-                        </div>
-                        <div>
-                            <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                                Current Stage
-                            </p>
-                            <span className={`mt-1 inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${selectedApplicant.pillClass}`}>
-                                {selectedApplicant.stage}
-                            </span>
-                        </div>
-                    </div>
-
-                    {/* Documents */}
-                    <div className="mb-6">
-                        <p className="mb-3 text-[10px] font-semibold uppercase tracking-widest text-slate-500">
-                            Documents
-                        </p>
-                        <div className="space-y-2">
-                            {MOCK_DOCS.map((doc) => (
-                                <div
-                                    key={doc}
-                                    className="flex items-center gap-3 rounded-xl border border-border bg-slate-50 px-3 py-2"
-                                >
-                                    <span className="text-slate-400 text-sm">📄</span>
-                                    <span className="text-xs font-medium text-foreground">{doc}</span>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Actions */}
-                    <div className="mt-auto flex gap-2">
-                        <Button variant="secondary" className="flex-1">
-                            Reject
-                        </Button>
-                        <Button className="flex-1">
-                            Approve
-                        </Button>
-                    </div>
-                </aside>
-            )}
-        </div>
-    );
+  return <RecruitmentList entries={entries || []} />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,11 @@ export default async function Home() {
               <h2 className="text-sm font-semibold uppercase tracking-[0.22em] text-stone-400">
                 Tenant theme config
               </h2>
-              <pre className="mt-5 overflow-x-auto rounded-2xl border border-white/5 bg-stone-950/70 p-4 text-xs leading-6 text-stone-200">{JSON.stringify(tenantContext.tenant.themeConfig, null, 2)}</pre>
+              <pre className="mt-5 overflow-x-auto rounded-2xl border border-white/5 bg-stone-950/70 p-4 text-xs leading-6 text-stone-200">
+                {Object.keys(tenantContext.tenant.themeConfig || {}).length > 0
+                  ? JSON.stringify(tenantContext.tenant.themeConfig, null, 2)
+                  : "No theme configured."}
+              </pre>
             </section>
           ) : null}
         </section>

--- a/src/components/organisms/application-board.tsx
+++ b/src/components/organisms/application-board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useOptimistic } from "react";
+import { useState, useOptimistic, startTransition } from "react";
 import { Button } from "@/components/atoms/button";
 import {
   updateApplicantStage,
@@ -56,17 +56,28 @@ export function ApplicationBoard({
   );
 
   async function handleMoveStage(applicantId: string, newStage: string) {
-    setOptimisticApplicants({ id: applicantId, stage: newStage });
-    // Also update server action
-    await updateApplicantStage(applicantId, newStage);
+    startTransition(() => {
+      setOptimisticApplicants({ id: applicantId, stage: newStage });
+    });
+    try {
+      await updateApplicantStage(applicantId, newStage);
+    } catch (e) {
+      alert("Failed to move stage.");
+    }
   }
 
   async function handleDecision(
     applicantId: string,
     status: "approved" | "rejected",
   ) {
-    setOptimisticApplicants({ id: applicantId, status });
-    await updateApplicantDecision(applicantId, status);
+    startTransition(() => {
+      setOptimisticApplicants({ id: applicantId, status });
+    });
+    try {
+      await updateApplicantDecision(applicantId, status);
+    } catch (e) {
+      alert("Failed to log decision.");
+    }
   }
 
   // Pre-process applicants per column

--- a/src/components/organisms/application-board.tsx
+++ b/src/components/organisms/application-board.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useOptimistic } from "react";
+import { Button } from "@/components/atoms/button";
+import {
+  updateApplicantStage,
+  updateApplicantDecision,
+} from "@/lib/actions/recruitment";
+import { Input } from "@/components/atoms/input";
+
+export type BoardApplicant = {
+  id: string;
+  name: string;
+  email: string;
+  stage: string;
+  status: string;
+  created_at: string;
+};
+
+const STAGES = [
+  { id: "application", label: "Application" },
+  { id: "screening", label: "Screening" },
+  { id: "interview", label: "Interview" },
+  { id: "deliberation", label: "Deliberation" },
+];
+
+export function ApplicationBoard({
+  entryTitle,
+  applicants,
+}: {
+  entryTitle: string;
+  applicants: BoardApplicant[];
+}) {
+  const [selectedApplicant, setSelectedApplicant] =
+    useState<BoardApplicant | null>(null);
+
+  const [optimisticApplicants, setOptimisticApplicants] = useOptimistic(
+    applicants,
+    (
+      state,
+      { id, stage, status }: { id: string; stage?: string; status?: string },
+    ) =>
+      state.map((app) =>
+        app.id === id
+          ? { ...app, ...(stage && { stage }), ...(status && { status }) }
+          : app,
+      ),
+  );
+
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredApplicants = optimisticApplicants.filter(
+    (a) =>
+      a.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      a.email.toLowerCase().includes(searchQuery.toLowerCase()),
+  );
+
+  async function handleMoveStage(applicantId: string, newStage: string) {
+    setOptimisticApplicants({ id: applicantId, stage: newStage });
+    // Also update server action
+    await updateApplicantStage(applicantId, newStage);
+  }
+
+  async function handleDecision(
+    applicantId: string,
+    status: "approved" | "rejected",
+  ) {
+    setOptimisticApplicants({ id: applicantId, status });
+    await updateApplicantDecision(applicantId, status);
+  }
+
+  // Pre-process applicants per column
+  const cols = STAGES.map((stage) => ({
+    ...stage,
+    applicants: filteredApplicants.filter(
+      (a) => (a.stage || "application") === stage.id,
+    ),
+  }));
+
+  return (
+    <div
+      className="flex -m-6 sm:-m-8 min-h-[calc(100vh-4rem)]"
+      style={{ fontFamily: "var(--font-body)" }}
+    >
+      {/* Kanban area */}
+      <div className="min-w-0 flex-1 overflow-y-auto p-6 sm:p-8">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wider text-slate-500 mb-1">
+              Pipeline
+            </p>
+            <h1
+              className="text-3xl font-bold tracking-tight text-foreground"
+              style={{ fontFamily: "var(--font-heading)" }}
+            >
+              {entryTitle}
+            </h1>
+          </div>
+          <Input
+            placeholder="Search applicants..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="max-w-xs"
+          />
+        </div>
+
+        {/* Columns grid view */}
+        <div className="flex gap-4 overflow-x-auto pb-4">
+          {cols.map((col) => (
+            <div
+              key={col.id}
+              className="w-80 shrink-0 rounded-2xl border border-border bg-slate-50 p-4"
+            >
+              <div className="mb-4 flex items-center justify-between">
+                <span className="text-sm font-semibold text-foreground">
+                  {col.label}
+                </span>
+                <span className="rounded-full border border-border bg-white px-2 py-0.5 text-xs text-slate-500">
+                  {col.applicants.length}
+                </span>
+              </div>
+
+              <div className="space-y-3 min-h-[500px]">
+                {col.applicants.map((a) => (
+                  <div
+                    key={a.id}
+                    onClick={() =>
+                      setSelectedApplicant(
+                        selectedApplicant?.id === a.id ? null : a,
+                      )
+                    }
+                    className={`cursor-pointer rounded-xl border p-4 shadow-sm transition-colors hover:border-primary/30 ${selectedApplicant?.id === a.id ? "border-primary ring-1 ring-primary/20 bg-primary/5" : "border-border bg-white"}`}
+                  >
+                    <div className="mb-2 flex items-center gap-2">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs font-bold text-slate-600">
+                        {a.name.slice(0, 2).toUpperCase()}
+                      </div>
+                      <span className="text-sm font-semibold text-foreground truncate">
+                        {a.name}
+                      </span>
+                    </div>
+                    <p className="mb-2 text-xs text-slate-500 truncate">
+                      {a.email}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Detail Panel */}
+      {selectedApplicant && (
+        <aside className="w-80 shrink-0 border-l border-border bg-white p-6 shadow-xl z-10 flex flex-col overflow-y-auto">
+          <button
+            type="button"
+            onClick={() => setSelectedApplicant(null)}
+            className="mb-4 self-end text-xs text-slate-400 transition-colors hover:text-foreground"
+          >
+            ✕ Close
+          </button>
+
+          <div className="mb-6 flex flex-col items-center text-center">
+            <div className="mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-lg font-bold text-primary">
+              {selectedApplicant.name.slice(0, 2).toUpperCase()}
+            </div>
+            <h2
+              className="text-lg font-bold text-foreground"
+              style={{ fontFamily: "var(--font-heading)" }}
+            >
+              {selectedApplicant.name}
+            </h2>
+            <p className="mt-0.5 text-xs text-slate-500">
+              {selectedApplicant.email}
+            </p>
+          </div>
+
+          <div className="mb-6 space-y-3 rounded-xl border border-border p-4 bg-slate-50">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Status
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {selectedApplicant.status}
+              </p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-widest text-slate-500">
+                Applied
+              </p>
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {new Date(selectedApplicant.created_at).toLocaleDateString()}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-bold text-slate-700">Move to Stage</h3>
+            <div className="flex flex-col gap-2">
+              {STAGES.map((s) => (
+                <Button
+                  key={s.id}
+                  variant={
+                    selectedApplicant.stage === s.id ? "default" : "outline"
+                  }
+                  onClick={() => {
+                    handleMoveStage(selectedApplicant.id, s.id);
+                    setSelectedApplicant((prev) =>
+                      prev ? { ...prev, stage: s.id } : null,
+                    );
+                  }}
+                  className="justify-start"
+                >
+                  {s.label}
+                </Button>
+              ))}
+            </div>
+
+            <div className="pt-4 mt-6 border-t border-slate-200">
+              <h3 className="text-sm font-bold text-slate-700 mb-3">
+                Final Decision
+              </h3>
+              <div className="flex flex-col gap-2">
+                <Button
+                  className="w-full bg-success hover:bg-success/90 text-white"
+                  onClick={() => {
+                    handleDecision(selectedApplicant.id, "approved");
+                    setSelectedApplicant((prev) =>
+                      prev ? { ...prev, status: "approved" } : null,
+                    );
+                  }}
+                  disabled={selectedApplicant.status === "approved"}
+                >
+                  Approve Applicant
+                </Button>
+                <Button
+                  className="w-full bg-destructive hover:bg-destructive/90 text-white"
+                  onClick={() => {
+                    handleDecision(selectedApplicant.id, "rejected");
+                    setSelectedApplicant((prev) =>
+                      prev ? { ...prev, status: "rejected" } : null,
+                    );
+                  }}
+                  disabled={selectedApplicant.status === "rejected"}
+                >
+                  Reject Applicant
+                </Button>
+              </div>
+            </div>
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/application-board.tsx
+++ b/src/components/organisms/application-board.tsx
@@ -202,7 +202,7 @@ export function ApplicationBoard({
                 <Button
                   key={s.id}
                   variant={
-                    selectedApplicant.stage === s.id ? "default" : "outline"
+                    selectedApplicant.stage === s.id ? "primary" : "ghost"
                   }
                   onClick={() => {
                     handleMoveStage(selectedApplicant.id, s.id);

--- a/src/components/organisms/login-form.tsx
+++ b/src/components/organisms/login-form.tsx
@@ -37,7 +37,7 @@ export function LoginForm() {
         title="Sign in"
       />
 
-      {state.error ? <StatusBanner tone="error">{state.error}</StatusBanner> : null}
+      {state.error ? <StatusBanner tone="error">{typeof state.error === 'string' && state.error !== '{}' ? state.error : 'An unexpected error occurred. Please try again.'}</StatusBanner> : null}
 
       <form action={formAction} className="flex flex-col gap-5" noValidate>
         <TextField

--- a/src/components/organisms/recruitment-list.tsx
+++ b/src/components/organisms/recruitment-list.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useOptimistic, useState } from "react";
+import { Button } from "@/components/atoms/button";
+import { Input } from "@/components/atoms/input";
+import { Label } from "@/components/atoms/label";
+import {
+  createRecruitmentEntry,
+  updateRecruitmentEntry,
+} from "@/lib/actions/recruitment";
+import Link from "next/link";
+
+type RecruitmentEntry = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  created_at: string;
+};
+
+export function RecruitmentList({ entries }: { entries: RecruitmentEntry[] }) {
+  const [optimisticEntries, dispatchOptimistic] = useOptimistic(
+    entries,
+    (state, action: { type: "add" | "update"; payload: RecruitmentEntry }) => {
+      if (action.type === "add") {
+        return [action.payload, ...state];
+      }
+      if (action.type === "update") {
+        return state.map((e) =>
+          e.id === action.payload.id ? { ...e, ...action.payload } : e,
+        );
+      }
+      return state;
+    },
+  );
+
+  const [isCreating, setIsCreating] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [statusFilter, setStatusFilter] = useState("all");
+
+  const filteredEntries = optimisticEntries.filter((entry) => {
+    const matchesSearch =
+      entry.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      (entry.description || "")
+        .toLowerCase()
+        .includes(searchQuery.toLowerCase());
+    const matchesStatus =
+      statusFilter === "all" || entry.status === statusFilter;
+    return matchesSearch && matchesStatus;
+  });
+
+  async function handleCreate(formData: FormData) {
+    const title = formData.get("title") as string;
+    const description = formData.get("description") as string;
+
+    if (!title) return;
+
+    const newEntry = {
+      id: crypto.randomUUID(),
+      title,
+      description,
+      status: "draft",
+      created_at: new Date().toISOString(),
+    };
+
+    // Optimistically add
+    dispatchOptimistic({ type: "add", payload: newEntry });
+
+    setIsCreating(false);
+
+    // Call server
+    await createRecruitmentEntry({ title, description, status: "draft" });
+  }
+
+  async function handleStatusChange(
+    entry: RecruitmentEntry,
+    newStatus: string,
+  ) {
+    dispatchOptimistic({
+      type: "update",
+      payload: { ...entry, status: newStatus },
+    });
+    await updateRecruitmentEntry({ id: entry.id, status: newStatus });
+  }
+
+  return (
+    <div
+      className="mx-auto max-w-4xl p-6 sm:p-8"
+      style={{ fontFamily: "var(--font-body)" }}
+    >
+      <div className="mb-6 flex items-center justify-between">
+        <h1
+          className="text-3xl font-bold tracking-tight text-foreground"
+          style={{ fontFamily: "var(--font-heading)" }}
+        >
+          Recruitment Cycles
+        </h1>
+        <Button onClick={() => setIsCreating(!isCreating)}>
+          {isCreating ? "Cancel" : "+ New Cycle"}
+        </Button>
+      </div>
+
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center justify-between">
+        <Input
+          placeholder="Search cycles..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="max-w-sm"
+        />
+        <div className="flex items-center gap-2">
+          <Label htmlFor="statusFilter" className="text-sm text-slate-500">
+            Filter:
+          </Label>
+          <select
+            id="statusFilter"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="h-10 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+          >
+            <option value="all">All Statuses</option>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+            <option value="paused">Paused</option>
+            <option value="closed">Closed</option>
+          </select>
+        </div>
+      </div>
+
+      {isCreating && (
+        <form
+          action={handleCreate}
+          className="mb-8 rounded-2xl border border-border bg-slate-50 p-6 shadow-sm"
+        >
+          <h2 className="mb-4 text-lg font-semibold">
+            Create New Recruitment Cycle
+          </h2>
+          <div className="mb-4 space-y-4">
+            <div>
+              <Label htmlFor="title">Title</Label>
+              <Input
+                id="title"
+                name="title"
+                required
+                placeholder="e.g. Spring 2026 Hiring"
+              />
+            </div>
+            <div>
+              <Label htmlFor="description">Description</Label>
+              <Input
+                id="description"
+                name="description"
+                placeholder="Brief details about this cycle"
+              />
+            </div>
+          </div>
+          <Button type="submit">Create Cycle</Button>
+        </form>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredEntries.map((entry) => (
+          <div
+            key={entry.id}
+            className="flex flex-col justify-between rounded-xl border border-border bg-white p-5 shadow-sm transition-colors hover:border-primary/30"
+          >
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <select
+                  value={entry.status}
+                  onChange={(e) => handleStatusChange(entry, e.target.value)}
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold uppercase appearance-none cursor-pointer border-none outline-none ${
+                    entry.status === "published"
+                      ? "bg-success/10 text-success"
+                      : entry.status === "closed"
+                        ? "bg-slate-100 text-slate-500"
+                        : "bg-warning/10 text-warning"
+                  }`}
+                >
+                  <option value="draft">Draft</option>
+                  <option value="published">Published</option>
+                  <option value="paused">Paused</option>
+                  <option value="closed">Closed</option>
+                </select>
+                <span className="text-xs text-slate-500">
+                  {new Date(entry.created_at).toLocaleDateString()}
+                </span>
+              </div>
+              <h3 className="mb-1 text-lg font-semibold text-foreground">
+                {entry.title}
+              </h3>
+              {entry.description && (
+                <p className="mb-4 text-sm text-slate-600 line-clamp-2">
+                  {entry.description}
+                </p>
+              )}
+            </div>
+
+            <Link
+              href={`/admin/recruitment/${entry.id}`}
+              className="mt-4 block w-full rounded-lg bg-slate-100 py-2 text-center text-sm font-semibold text-slate-700 transition hover:bg-slate-200"
+            >
+              View Pipeline
+            </Link>
+          </div>
+        ))}
+
+        {filteredEntries.length === 0 && !isCreating && (
+          <div className="col-span-full py-12 text-center text-slate-500">
+            No recruitment cycles found.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/recruitment-list.tsx
+++ b/src/components/organisms/recruitment-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useOptimistic, useState } from "react";
+import { useOptimistic, useState, startTransition } from "react";
 import { Button } from "@/components/atoms/button";
 import { Input } from "@/components/atoms/input";
 import { Label } from "@/components/atoms/label";
@@ -51,7 +51,7 @@ export function RecruitmentList({ entries }: { entries: RecruitmentEntry[] }) {
 
   async function handleCreate(formData: FormData) {
     const title = formData.get("title") as string;
-    const description = formData.get("description") as string;
+    const description = (formData.get("description") ?? "").toString();
 
     if (!title) return;
 
@@ -64,23 +64,35 @@ export function RecruitmentList({ entries }: { entries: RecruitmentEntry[] }) {
     };
 
     // Optimistically add
-    dispatchOptimistic({ type: "add", payload: newEntry });
+    startTransition(() => {
+      dispatchOptimistic({ type: "add", payload: newEntry });
+    });
 
     setIsCreating(false);
 
-    // Call server
-    await createRecruitmentEntry({ title, description, status: "draft" });
+    try {
+      // Call server
+      await createRecruitmentEntry({ title, description, status: "draft" });
+    } catch (e) {
+      alert("Failed to create entry.");
+    }
   }
 
   async function handleStatusChange(
     entry: RecruitmentEntry,
     newStatus: string,
   ) {
-    dispatchOptimistic({
-      type: "update",
-      payload: { ...entry, status: newStatus },
+    startTransition(() => {
+      dispatchOptimistic({
+        type: "update",
+        payload: { ...entry, status: newStatus },
+      });
     });
-    await updateRecruitmentEntry({ id: entry.id, status: newStatus });
+    try {
+      await updateRecruitmentEntry({ id: entry.id, status: newStatus });
+    } catch (e) {
+      alert("Failed to update status.");
+    }
   }
 
   return (
@@ -95,7 +107,12 @@ export function RecruitmentList({ entries }: { entries: RecruitmentEntry[] }) {
         >
           Recruitment Cycles
         </h1>
-        <Button onClick={() => setIsCreating(!isCreating)}>
+        <Button 
+          onClick={() => {
+            console.log("Button clicked!");
+            setIsCreating((prev) => !prev);
+          }}
+        >
           {isCreating ? "Cancel" : "+ New Cycle"}
         </Button>
       </div>
@@ -168,12 +185,14 @@ export function RecruitmentList({ entries }: { entries: RecruitmentEntry[] }) {
                 <select
                   value={entry.status}
                   onChange={(e) => handleStatusChange(entry, e.target.value)}
-                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold uppercase appearance-none cursor-pointer border-none outline-none ${
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold uppercase cursor-pointer border-none outline-none ${
                     entry.status === "published"
                       ? "bg-success/10 text-success"
                       : entry.status === "closed"
                         ? "bg-slate-100 text-slate-500"
-                        : "bg-warning/10 text-warning"
+                        : entry.status === "paused"
+                          ? "bg-purple-100 text-purple-700" 
+                          : "bg-warning/10 text-warning"
                   }`}
                 >
                   <option value="draft">Draft</option>

--- a/src/lib/actions/recruitment.ts
+++ b/src/lib/actions/recruitment.ts
@@ -69,15 +69,15 @@ export async function updateRecruitmentEntry(rawInput: unknown) {
   }
 
   const input = updateEntrySchema.parse(rawInput);
+  const { id, ...rawUpdates } = input;
+  const updates = Object.fromEntries(
+    Object.entries(rawUpdates).filter(([, value]) => value !== undefined),
+  );
 
   const { data, error } = await adminClient
     .from("recruitment_entries")
-    .update({
-      title: input.title,
-      description: input.description,
-      status: input.status,
-    })
-    .eq("id", input.id)
+    .update(updates)
+    .eq("id", id)
     .eq("tenant_id", tenant.id)
     .select()
     .single();

--- a/src/lib/actions/recruitment.ts
+++ b/src/lib/actions/recruitment.ts
@@ -1,0 +1,161 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
+import { z } from "zod";
+
+const createEntrySchema = z.object({
+  title: z.string().min(1),
+  description: z.string().optional(),
+  status: z.enum(["draft", "published", "paused", "closed"]).default("draft"),
+});
+
+const updateEntrySchema = createEntrySchema.partial().extend({
+  id: z.string().uuid(),
+});
+
+export async function createRecruitmentEntry(rawInput: unknown) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("create-recruitment");
+
+  if (
+    !tenant ||
+    !adminClient ||
+    !viewer ||
+    !canManageTemporaryApplicants(viewer)
+  ) {
+    throw new Error(
+      "You do not have permission to manage recruitment entries.",
+    );
+  }
+
+  const input = createEntrySchema.parse(rawInput);
+
+  const { data, error } = await adminClient
+    .from("recruitment_entries")
+    .insert({
+      tenant_id: tenant.id,
+      title: input.title,
+      description: input.description,
+      status: input.status,
+      created_by: viewer.id,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/recruitment");
+  return data;
+}
+
+export async function updateRecruitmentEntry(rawInput: unknown) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("update-recruitment");
+
+  if (
+    !tenant ||
+    !adminClient ||
+    !viewer ||
+    !canManageTemporaryApplicants(viewer)
+  ) {
+    throw new Error(
+      "You do not have permission to manage recruitment entries.",
+    );
+  }
+
+  const input = updateEntrySchema.parse(rawInput);
+
+  const { data, error } = await adminClient
+    .from("recruitment_entries")
+    .update({
+      title: input.title,
+      description: input.description,
+      status: input.status,
+    })
+    .eq("id", input.id)
+    .eq("tenant_id", tenant.id)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/recruitment");
+  return data;
+}
+
+export async function updateApplicantStage(applicantId: string, stage: string) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("update-applicant-stage");
+
+  if (
+    !tenant ||
+    !adminClient ||
+    !viewer ||
+    !canManageTemporaryApplicants(viewer)
+  ) {
+    throw new Error("You do not have permission to manage applicants.");
+  }
+
+  // Fetch current data
+  const { data: current, error: fetchErr } = await adminClient
+    .from("temporary_applicants")
+    .select("application_data")
+    .eq("id", applicantId)
+    .eq("tenant_id", tenant.id)
+    .single();
+
+  if (fetchErr) throw new Error(fetchErr.message);
+
+  // Update jsonb safely
+  const updatedData = { ...current.application_data, stage };
+
+  const { data, error } = await adminClient
+    .from("temporary_applicants")
+    .update({ application_data: updatedData })
+    .eq("id", applicantId)
+    .eq("tenant_id", tenant.id)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/recruitment");
+  return data;
+}
+
+export async function updateApplicantDecision(
+  applicantId: string,
+  status: "approved" | "rejected",
+) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const adminClient = createSupabaseAdminClient("update-applicant-decision");
+
+  if (
+    !tenant ||
+    !adminClient ||
+    !viewer ||
+    !canManageTemporaryApplicants(viewer)
+  ) {
+    throw new Error("You do not have permission to manage applicants.");
+  }
+
+  const { data, error } = await adminClient
+    .from("temporary_applicants")
+    .update({ status })
+    .eq("id", applicantId)
+    .eq("tenant_id", tenant.id)
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/recruitment");
+  return data;
+}

--- a/src/lib/actions/recruitment.ts
+++ b/src/lib/actions/recruitment.ts
@@ -1,8 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
-import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { resolveCurrentTenant, getCurrentViewer, createSupabaseUserClient } from "@/lib/supabase/server";
 import { canManageTemporaryApplicants } from "@/lib/organization-permissions";
 import { z } from "zod";
 
@@ -19,11 +18,11 @@ const updateEntrySchema = createEntrySchema.partial().extend({
 export async function createRecruitmentEntry(rawInput: unknown) {
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("create-recruitment");
+  const userClient = await createSupabaseUserClient();
 
   if (
     !tenant ||
-    !adminClient ||
+    !userClient ||
     !viewer ||
     !canManageTemporaryApplicants(viewer)
   ) {
@@ -34,7 +33,7 @@ export async function createRecruitmentEntry(rawInput: unknown) {
 
   const input = createEntrySchema.parse(rawInput);
 
-  const { data, error } = await adminClient
+  const { data, error } = await userClient
     .from("recruitment_entries")
     .insert({
       tenant_id: tenant.id,
@@ -55,11 +54,11 @@ export async function createRecruitmentEntry(rawInput: unknown) {
 export async function updateRecruitmentEntry(rawInput: unknown) {
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("update-recruitment");
+  const userClient = await createSupabaseUserClient();
 
   if (
     !tenant ||
-    !adminClient ||
+    !userClient ||
     !viewer ||
     !canManageTemporaryApplicants(viewer)
   ) {
@@ -74,7 +73,7 @@ export async function updateRecruitmentEntry(rawInput: unknown) {
     Object.entries(rawUpdates).filter(([, value]) => value !== undefined),
   );
 
-  const { data, error } = await adminClient
+  const { data, error } = await userClient
     .from("recruitment_entries")
     .update(updates)
     .eq("id", id)
@@ -88,22 +87,26 @@ export async function updateRecruitmentEntry(rawInput: unknown) {
   return data;
 }
 
+const updateStageSchema = z.enum(["application", "screening", "interview", "deliberation"]);
+
 export async function updateApplicantStage(applicantId: string, stage: string) {
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("update-applicant-stage");
+  const userClient = await createSupabaseUserClient();
 
   if (
     !tenant ||
-    !adminClient ||
+    !userClient ||
     !viewer ||
     !canManageTemporaryApplicants(viewer)
   ) {
     throw new Error("You do not have permission to manage applicants.");
   }
+  
+  const parsedStage = updateStageSchema.parse(stage);
 
   // Fetch current data
-  const { data: current, error: fetchErr } = await adminClient
+  const { data: current, error: fetchErr } = await userClient
     .from("temporary_applicants")
     .select("application_data")
     .eq("id", applicantId)
@@ -113,9 +116,10 @@ export async function updateApplicantStage(applicantId: string, stage: string) {
   if (fetchErr) throw new Error(fetchErr.message);
 
   // Update jsonb safely
-  const updatedData = { ...current.application_data, stage };
+  const applicationData = current.application_data && typeof current.application_data === "object" ? current.application_data : {};
+  const updatedData = { ...applicationData, stage: parsedStage };
 
-  const { data, error } = await adminClient
+  const { data, error } = await userClient
     .from("temporary_applicants")
     .update({ application_data: updatedData })
     .eq("id", applicantId)
@@ -135,18 +139,18 @@ export async function updateApplicantDecision(
 ) {
   const { tenant } = await resolveCurrentTenant();
   const viewer = await getCurrentViewer();
-  const adminClient = createSupabaseAdminClient("update-applicant-decision");
+  const userClient = await createSupabaseUserClient();
 
   if (
     !tenant ||
-    !adminClient ||
+    !userClient ||
     !viewer ||
     !canManageTemporaryApplicants(viewer)
   ) {
     throw new Error("You do not have permission to manage applicants.");
   }
 
-  const { data, error } = await adminClient
+  const { data, error } = await userClient
     .from("temporary_applicants")
     .update({ status })
     .eq("id", applicantId)

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -86,7 +86,7 @@ function isInvalidRefreshTokenError(error: unknown) {
   );
 }
 
-async function createSupabaseUserClient() {
+export async function createSupabaseUserClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 

--- a/supabase/migrations/20260517134539_add_recruitment_entries.sql
+++ b/supabase/migrations/20260517134539_add_recruitment_entries.sql
@@ -1,0 +1,36 @@
+create table public.recruitment_entries (
+  id uuid primary key default extensions.gen_random_uuid(),
+  tenant_id uuid not null references public.organizations(id) on delete cascade,
+  title text not null,
+  description text,
+  status text not null default 'draft' check (status in ('draft', 'published', 'paused', 'closed')),
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create index recruitment_entries_tenant_id_idx on public.recruitment_entries (tenant_id);
+
+create trigger set_recruitment_entries_updated_at
+  before update on public.recruitment_entries
+  for each row execute function public.set_current_timestamp();
+
+alter table public.temporary_applicants 
+  add column recruitment_entry_id uuid references public.recruitment_entries(id) on delete set null;
+
+create index temporary_applicants_recruitment_entry_id_idx on public.temporary_applicants (recruitment_entry_id);
+
+-- Apply Security Rules
+alter table public.recruitment_entries enable row level security;
+
+create policy "tenant_isolation" on public.recruitment_entries
+  for all to authenticated
+  using (public.has_tenant_access(tenant_id))
+  with check (public.has_tenant_access(tenant_id));
+
+create trigger enforce_recruitment_entries_tenant_scope
+  before insert or update on public.recruitment_entries
+  for each row execute function public.enforce_tenant_scope();
+
+grant all on public.recruitment_entries to authenticated;
+grant all on public.recruitment_entries to service_role;

--- a/supabase/snippets/Untitled query 114.sql
+++ b/supabase/snippets/Untitled query 114.sql
@@ -1,3 +1,0 @@
--- Removed accidental Supabase Studio scratch query.
--- If this data is actually needed for local development, move it into
--- `supabase/seed.sql` and make it idempotent with `NOT EXISTS` guards.

--- a/supabase/snippets/Untitled query 114.sql
+++ b/supabase/snippets/Untitled query 114.sql
@@ -1,0 +1,31 @@
+DO $$
+DECLARE
+  v_tenant_id uuid;
+  v_entry_id uuid;
+BEGIN
+  -- 1. Get the Acme organization ID
+  SELECT id INTO v_tenant_id FROM public.organizations WHERE slug = 'acme' LIMIT 1;
+  
+  -- 2. Create a test recruitment cycle
+  INSERT INTO public.recruitment_entries (tenant_id, title, description, status)
+  VALUES (v_tenant_id, 'Fall 2026 Hiring (Test)', 'This is a test cycle', 'published')
+  RETURNING id INTO v_entry_id;
+  
+  -- 3. Insert Jane Doe into that cycle
+  INSERT INTO public.temporary_applicants (
+    tenant_id, 
+    applicant_name, 
+    applicant_email, 
+    status, 
+    recruitment_entry_id, 
+    application_data
+  )
+  VALUES (
+    v_tenant_id, 
+    'Jane Doe', 
+    'jane@example.com', 
+    'invited', 
+    v_entry_id, 
+    '{"stage": "application"}'::jsonb
+  );
+END $$;

--- a/supabase/snippets/Untitled query 114.sql
+++ b/supabase/snippets/Untitled query 114.sql
@@ -1,31 +1,3 @@
-DO $$
-DECLARE
-  v_tenant_id uuid;
-  v_entry_id uuid;
-BEGIN
-  -- 1. Get the Acme organization ID
-  SELECT id INTO v_tenant_id FROM public.organizations WHERE slug = 'acme' LIMIT 1;
-  
-  -- 2. Create a test recruitment cycle
-  INSERT INTO public.recruitment_entries (tenant_id, title, description, status)
-  VALUES (v_tenant_id, 'Fall 2026 Hiring (Test)', 'This is a test cycle', 'published')
-  RETURNING id INTO v_entry_id;
-  
-  -- 3. Insert Jane Doe into that cycle
-  INSERT INTO public.temporary_applicants (
-    tenant_id, 
-    applicant_name, 
-    applicant_email, 
-    status, 
-    recruitment_entry_id, 
-    application_data
-  )
-  VALUES (
-    v_tenant_id, 
-    'Jane Doe', 
-    'jane@example.com', 
-    'invited', 
-    v_entry_id, 
-    '{"stage": "application"}'::jsonb
-  );
-END $$;
+-- Removed accidental Supabase Studio scratch query.
+-- If this data is actually needed for local development, move it into
+-- `supabase/seed.sql` and make it idempotent with `NOT EXISTS` guards.

--- a/supabase/tests/recruitment_entries.sql
+++ b/supabase/tests/recruitment_entries.sql
@@ -1,0 +1,107 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(5);
+
+select has_table('public', 'recruitment_entries', 'recruitment_entries table exists');
+select has_column('public', 'recruitment_entries', 'tenant_id', 'recruitment_entries has tenant_id');
+select policies_are(
+  'public',
+  'recruitment_entries',
+  array['tenant_isolation']
+);
+
+insert into public.organizations (id, slug, name)
+values
+  ('92000000-0000-0000-0000-000000000001', 'tenant-one', 'Tenant One'),
+  ('92000000-0000-0000-0000-000000000002', 'tenant-two', 'Tenant Two');
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '92000000-0000-0000-0000-000000000011',
+    'authenticated',
+    'authenticated',
+    'tenant-one@test.salina.dev',
+    extensions.crypt('password123', extensions.gen_salt('bf')),
+    timezone('utc', now()),
+    jsonb_build_object('tenant_id', '92000000-0000-0000-0000-000000000001', 'temporary_applicant', true),
+    '{}'::jsonb,
+    timezone('utc', now()),
+    timezone('utc', now())
+  ),
+  (
+    '92000000-0000-0000-0000-000000000022',
+    'authenticated',
+    'authenticated',
+    'tenant-two@test.salina.dev',
+    extensions.crypt('password123', extensions.gen_salt('bf')),
+    timezone('utc', now()),
+    jsonb_build_object('tenant_id', '92000000-0000-0000-0000-000000000002', 'temporary_applicant', true),
+    '{}'::jsonb,
+    timezone('utc', now()),
+    timezone('utc', now())
+  );
+
+insert into public.recruitment_entries (
+  id,
+  tenant_id,
+  title,
+  status,
+  created_by
+)
+values
+  (
+    '92000000-0000-0000-0000-000000000033',
+    '92000000-0000-0000-0000-000000000001',
+    'Tenant One Recruitment',
+    'draft',
+    null
+  ),
+  (
+    '92000000-0000-0000-0000-000000000044',
+    '92000000-0000-0000-0000-000000000002',
+    'Tenant Two Recruitment',
+    'draft',
+    null
+  );
+
+set local role authenticated;
+set local "request.jwt.claims" = '{"role":"authenticated","sub":"92000000-0000-0000-0000-000000000011","app_metadata":{"tenant_id":"92000000-0000-0000-0000-000000000001"}}';
+
+select results_eq(
+  'select count(*)::bigint from public.recruitment_entries',
+  array[1::bigint],
+  'tenant one only sees its own recruitment entries'
+);
+
+set local "request.jwt.claims" = '{"role":"authenticated","sub":"92000000-0000-0000-0000-000000000022","app_metadata":{"tenant_id":"92000000-0000-0000-0000-000000000002"}}';
+
+select results_eq(
+  $$
+    with touched as (
+      update public.recruitment_entries
+      set title = 'Hacked'
+      where id = '92000000-0000-0000-0000-000000000033'
+      returning id
+    )
+    select count(*)::bigint from touched
+  $$,
+  array[0::bigint],
+  'cross-tenant updates are blocked by RLS'
+);
+
+select * from finish();
+rollback;

--- a/test-login.mjs
+++ b/test-login.mjs
@@ -1,0 +1,4 @@
+
+import { headers } from "next/headers";
+// Instead of messing with NextJS server actions formatting, I will use playwright to test it
+


### PR DESCRIPTION
- Organization admins can view all recruitment entries for their organization, including current and past items.

Implemented: Yes. Admin view at /admin/recruitment/ displays all cycles fetched securely via [tenant.id](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Organization admins can create, edit, publish, pause, and close recruitment entries.

Implemented: Yes. You can create cycles with the "+ New Cycle" button, and you added a dropdown on each cycle card to change between Draft/Published/Paused/Closed states inline.

- Organization admins can review applicant submissions, update application status, and record recruitment decisions.

Implemented: Yes. Your screenshot shows Jane Doe under "Application". You can click her, move her stage (Screening/Interview/Deliberation) using the detail panel we built, and ultimately click "Approve" or "Reject".

- Organization admins can filter or search recruitment items and applicants to manage them efficiently.

Implemented: Yes. In your screenshot, there is a "Search applicants..." bar on the right side. And on the main list page, there's a cycle search/filter bar.

- Only users with the correct organization admin permission can access and modify the Recruitment tab.

Implemented: Yes. Both the [page.tsx](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) routes and the server actions tightly integrate [canManageTemporaryApplicants(viewer)](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) ensuring members missing roles like Owner/Admin are booted back to the dashboard or blocked from API.

- Recruitment changes persist correctly and are reflected in the UI immediately.

Implemented: Yes. Dragging/moving users leverages React's [useOptimistic](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) hook for instantaneous visual feedback while Server Actions (like [updateApplicantDecision](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) execute the Postgres query and call [revalidatePath](vscode-file://vscode-app/c:/Users/jcnru/AppData/Local/Programs/Microsoft%20VS%20Code/0958016b2a/resources/app/out/vs/code/electron-browser/workbench/workbench.html) behind the scenes.