### PR TITLE
feat(member): add member settings page and fix layout display names

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -70,8 +70,9 @@ export default async function AdminLayout({
           tenantContext.tenant.themeConfig.primaryColor ?? "#c6623e",
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
+        fontFamily: tenantContext.tenant.themeConfig.fontFamily ?? undefined,
       }}
-      userName={viewer.email?.split("@")[0] ?? "Admin"}
+      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Admin"}
       userId={viewer.id}
       tenantId={viewer.tenantId}
     >

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -71,13 +71,9 @@ export default async function AdminLayout({
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
       }}
-<<<<<<< HEAD
-      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Admin"}
-=======
       userName={viewer.email?.split("@")[0] ?? "Admin"}
       userId={viewer.id}
       tenantId={viewer.tenantId}
->>>>>>> origin
     >
       {children}
     </AuthenticatedShell>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -64,7 +64,7 @@ export default async function AdminLayout({
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
       }}
-      userName={viewer.email?.split("@")[0] ?? "Admin"}
+      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Admin"}
     >
       {children}
     </AuthenticatedShell>

--- a/src/app/member/layout.tsx
+++ b/src/app/member/layout.tsx
@@ -85,14 +85,10 @@ export default async function MemberLayout({
               }
             : undefined
         }
-<<<<<<< HEAD
-        userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Member"}
-=======
         userName={viewer.email?.split("@")[0] ?? "Member"}
         customPermissions={viewer.customPermissions}
         userId={viewer.id}
         tenantId={viewer.tenantId}
->>>>>>> origin
       >
         {children}
       </AuthenticatedShell>

--- a/src/app/member/layout.tsx
+++ b/src/app/member/layout.tsx
@@ -82,10 +82,12 @@ export default async function MemberLayout({
                   tenantContext.tenant.themeConfig.primaryColor ?? "#c6623e",
                 textColor: "#ffffff",
                 logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
+                fontFamily:
+                  tenantContext.tenant.themeConfig.fontFamily ?? undefined,
               }
             : undefined
         }
-        userName={viewer.email?.split("@")[0] ?? "Member"}
+        userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Member"}
         customPermissions={viewer.customPermissions}
         userId={viewer.id}
         tenantId={viewer.tenantId}

--- a/src/app/member/layout.tsx
+++ b/src/app/member/layout.tsx
@@ -63,7 +63,10 @@ export default async function MemberLayout({
 
   // Compute switchable roles from the viewer's actual DB role.
   // Admin/Officer accessing member pages will see their higher-role chips to switch back.
-  const switchableRoles: UserRole[] = getSwitchableRoles(viewer.tenantRole, "Member");
+  const switchableRoles: UserRole[] = getSwitchableRoles(
+    viewer.tenantRole,
+    "Member",
+  );
 
   return (
     <TemporaryApplicantProvider value={viewer.isTemporaryApplicant ?? false}>
@@ -82,7 +85,7 @@ export default async function MemberLayout({
               }
             : undefined
         }
-        userName={viewer.email?.split("@")[0] ?? "Member"}
+        userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Member"}
       >
         {children}
       </AuthenticatedShell>

--- a/src/app/member/settings/page.tsx
+++ b/src/app/member/settings/page.tsx
@@ -1,0 +1,40 @@
+import { redirect } from "next/navigation";
+import { createUserClient } from "@/lib/supabase/user-server";
+import { LOCAL_COOKIE_DOMAIN } from "@/lib/host-routing";
+import { SettingsForms } from "./settings-forms";
+
+export const metadata = {
+  title: "Settings",
+};
+
+export default async function SettingsPage() {
+  const supabase = await createUserClient(LOCAL_COOKIE_DOMAIN);
+
+  if (!supabase) {
+    redirect("/login");
+  }
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect("/login");
+  }
+
+  const userMetadata = user.user_metadata || {};
+  const displayName =
+    userMetadata.display_name || user.email?.split("@")[0] || "";
+  const avatarUrl = userMetadata.avatar_url || "";
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <h1 className="mb-6 text-2xl font-bold text-slate-900">Settings</h1>
+      <SettingsForms
+        initialDisplayName={displayName}
+        initialAvatarUrl={avatarUrl}
+      />
+    </div>
+  );
+}

--- a/src/app/member/settings/settings-forms.tsx
+++ b/src/app/member/settings/settings-forms.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useActionState, useEffect, useState, useMemo } from "react";
+import { updateProfileAction, changePasswordAction } from "@/lib/actions/auth";
+import { Input } from "@/components/atoms/input";
+import { Button } from "@/components/atoms/button";
+import { Switch } from "@/components/atoms/switch";
+import { FieldMessage } from "@/components/atoms/field-message";
+import { Label } from "@/components/atoms/label";
+
+function getInitials(name: string) {
+  return (
+    name
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? "")
+      .join("") || "U"
+  );
+}
+
+export function SettingsForms({
+  initialDisplayName,
+  initialAvatarUrl,
+}: {
+  initialDisplayName: string;
+  initialAvatarUrl: string;
+}) {
+  const [profileState, profileAction, isProfilePending] = useActionState(
+    updateProfileAction,
+    {},
+  );
+  const [passwordState, passwordAction, isPasswordPending] = useActionState(
+    changePasswordAction,
+    {},
+  );
+
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [avatarUrl, setAvatarUrl] = useState(initialAvatarUrl);
+
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("salina_notifications");
+    if (saved !== null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setNotificationsEnabled(saved === "true");
+    }
+  }, []);
+
+  const handleToggleNotifications = (checked: boolean) => {
+    setNotificationsEnabled(checked);
+    localStorage.setItem("salina_notifications", String(checked));
+  };
+
+  const initials = useMemo(() => getInitials(displayName), [displayName]);
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Profile Section */}
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">Profile</h2>
+        <form action={profileAction} className="flex flex-col gap-5">
+          <div className="flex items-center gap-6">
+            <div className="flex h-20 w-20 shrink-0 items-center justify-center overflow-hidden rounded-full border border-slate-200 bg-slate-100 shadow-inner">
+              {avatarUrl ? (
+                <div
+                  className="h-full w-full bg-cover bg-center bg-no-repeat"
+                  style={{ backgroundImage: `url(${avatarUrl})` }}
+                />
+              ) : (
+                <span className="text-2xl font-bold text-slate-600">
+                  {initials}
+                </span>
+              )}
+            </div>
+            <div className="flex-1">
+              <Label htmlFor="avatarUrl">Avatar URL</Label>
+              <Input
+                id="avatarUrl"
+                name="avatarUrl"
+                type="url"
+                placeholder="https://example.com/avatar.png"
+                value={avatarUrl}
+                onChange={(e) => setAvatarUrl(e.target.value)}
+                className="mt-1"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Provide a URL to your avatar image, or leave blank to use
+                initials.
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <Label htmlFor="displayName">Display Name</Label>
+            <Input
+              id="displayName"
+              name="displayName"
+              type="text"
+              required
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="mt-1"
+            />
+          </div>
+
+          {profileState.error && (
+            <FieldMessage variant="error">{profileState.error}</FieldMessage>
+          )}
+          {profileState.success && (
+            <FieldMessage variant="success">
+              {profileState.success}
+            </FieldMessage>
+          )}
+
+          <div className="mt-2">
+            <Button type="submit" disabled={isProfilePending}>
+              {isProfilePending ? "Saving..." : "Save Profile"}
+            </Button>
+          </div>
+        </form>
+      </section>
+
+      {/* Notifications Section */}
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">
+          Preferences
+        </h2>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium text-slate-800">
+              Email Notifications
+            </h3>
+            <p className="text-sm text-slate-500">
+              Receive updates and alerts via email.
+            </p>
+          </div>
+          <Switch
+            id="notifications"
+            checked={notificationsEnabled}
+            onChange={handleToggleNotifications}
+          />
+        </div>
+      </section>
+
+      {/* Password Section */}
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">
+          Change Password
+        </h2>
+        <form action={passwordAction} className="flex flex-col gap-4">
+          <div>
+            <Label htmlFor="newPassword">New Password</Label>
+            <Input
+              id="newPassword"
+              name="newPassword"
+              type="password"
+              required
+              className="mt-1"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="confirmPassword">Confirm Password</Label>
+            <Input
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              required
+              className="mt-1"
+            />
+          </div>
+
+          {passwordState.error && (
+            <FieldMessage variant="error">{passwordState.error}</FieldMessage>
+          )}
+          {passwordState.success && (
+            <FieldMessage variant="success">
+              {passwordState.success}
+            </FieldMessage>
+          )}
+
+          <div className="mt-2">
+            <Button
+              type="submit"
+              disabled={isPasswordPending}
+              variant="secondary"
+            >
+              {isPasswordPending ? "Updating..." : "Update Password"}
+            </Button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/app/officer/layout.tsx
+++ b/src/app/officer/layout.tsx
@@ -59,8 +59,9 @@ export default async function OfficerLayout({
           tenantContext.tenant.themeConfig.primaryColor ?? "#c6623e",
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
+        fontFamily: tenantContext.tenant.themeConfig.fontFamily ?? undefined,
       }}
-      userName={viewer.email?.split("@")[0] ?? "Officer"}
+      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Officer"}
       customPermissions={viewer.customPermissions}
       userId={viewer.id}
       tenantId={viewer.tenantId}

--- a/src/app/officer/layout.tsx
+++ b/src/app/officer/layout.tsx
@@ -45,7 +45,7 @@ export default async function OfficerLayout({
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
       }}
-      userName={viewer.email?.split("@")[0] ?? "Officer"}
+      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Officer"}
     >
       {children}
     </AuthenticatedShell>

--- a/src/app/officer/layout.tsx
+++ b/src/app/officer/layout.tsx
@@ -60,14 +60,10 @@ export default async function OfficerLayout({
         textColor: "#ffffff",
         logoUrl: tenantContext.tenant.themeConfig.logoUrl ?? undefined,
       }}
-<<<<<<< HEAD
-      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "Officer"}
-=======
       userName={viewer.email?.split("@")[0] ?? "Officer"}
       customPermissions={viewer.customPermissions}
       userId={viewer.id}
       tenantId={viewer.tenantId}
->>>>>>> origin
     >
       {children}
     </AuthenticatedShell>

--- a/src/app/superadmin/layout.tsx
+++ b/src/app/superadmin/layout.tsx
@@ -18,7 +18,7 @@ export default async function SuperAdminLayout({
   return (
     <AuthenticatedShell
       role="SuperAdmin"
-      userName={viewer.email?.split("@")[0] ?? "System Admin"}
+      userName={viewer.displayName ?? viewer.email?.split("@")[0] ?? "System Admin"}
       userId={viewer.id}
       tenantId={viewer.tenantId}
     >

--- a/src/app/superadmin/layout.tsx
+++ b/src/app/superadmin/layout.tsx
@@ -15,14 +15,6 @@ export default async function SuperAdminLayout({
     redirect("/login");
   }
 
-<<<<<<< HEAD
-    return (
-        <AuthenticatedShell role="SuperAdmin" userName={viewer.displayName ?? viewer.email?.split('@')[0] ?? 'System Admin'}>
-            {children}
-        </AuthenticatedShell>
-    );
-}
-=======
   return (
     <AuthenticatedShell
       role="SuperAdmin"
@@ -34,4 +26,3 @@ export default async function SuperAdminLayout({
     </AuthenticatedShell>
   );
 }
->>>>>>> origin

--- a/src/app/superadmin/layout.tsx
+++ b/src/app/superadmin/layout.tsx
@@ -12,7 +12,7 @@ export default async function SuperAdminLayout({ children }: { children: ReactNo
     }
 
     return (
-        <AuthenticatedShell role="SuperAdmin" userName={viewer.email?.split('@')[0] ?? 'System Admin'}>
+        <AuthenticatedShell role="SuperAdmin" userName={viewer.displayName ?? viewer.email?.split('@')[0] ?? 'System Admin'}>
             {children}
         </AuthenticatedShell>
     );

--- a/src/components/molecules/authenticated-top-bar.tsx
+++ b/src/components/molecules/authenticated-top-bar.tsx
@@ -18,6 +18,7 @@ export interface AuthenticatedTenantBranding {
   textColor: string;
   logo?: string;
   logoUrl?: string;
+  fontFamily?: string;
 }
 
 interface AuthenticatedTopBarProps {

--- a/src/components/organisms/feedback-modal.tsx
+++ b/src/components/organisms/feedback-modal.tsx
@@ -3,138 +3,218 @@ import { cn } from "@/lib/utils";
 export type FeedbackTone = "error" | "warning" | "success" | "info";
 
 interface FeedbackModalProps {
-    isOpen: boolean;
-    onClose: () => void;
-    tone?: FeedbackTone;
-    title: string;
-    message: string;
-    confirmText?: string;
-    cancelText?: string;
-    onConfirm?: () => void;
-    showCancel?: boolean;
-    primaryColor?: string;
-    actions?: {
-        label: string;
-        onClick: () => void;
-        isPrimary?: boolean;
-    }[];
+  isOpen: boolean;
+  onClose: () => void;
+  tone?: FeedbackTone;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: () => void;
+  showCancel?: boolean;
+  primaryColor?: string;
+  actions?: {
+    label: string;
+    onClick: () => void;
+    isPrimary?: boolean;
+  }[];
 }
 
 export function FeedbackModal({
-    isOpen,
-    onClose,
-    tone = "info",
-    title,
-    message,
-    confirmText = "Okay",
-    cancelText = "Cancel",
-    onConfirm,
-    showCancel = false,
-    primaryColor,
-    actions
+  isOpen,
+  onClose,
+  tone = "info",
+  title,
+  message,
+  confirmText = "Okay",
+  cancelText = "Cancel",
+  onConfirm,
+  showCancel = false,
+  primaryColor,
+  actions,
 }: FeedbackModalProps) {
-    if (!isOpen) return null;
+  if (!isOpen) return null;
 
-    // Determine if we should override the default colors with the tenant's brand color
-    const isBrandThemed = !!primaryColor && (tone === "info" || tone === "success");
+  // Determine if we should override the default colors with the tenant's brand color
+  const isBrandThemed =
+    !!primaryColor && (tone === "info" || tone === "success");
 
-    // Dynamic configuration based on the tone
-    const toneConfig = {
-        error: {
-            icon: <svg className="w-6 h-6 text-rose-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>,
-            bgClass: "bg-rose-100",
-            buttonClass: "bg-rose-600 hover:bg-rose-700 text-white shadow-md"
-        },
-        warning: {
-            icon: <svg className="w-6 h-6 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>,
-            bgClass: "bg-amber-100",
-            buttonClass: "bg-amber-500 hover:bg-amber-600 text-white shadow-md"
-        },
-        success: {
-            icon: <svg className={cn("w-6 h-6", isBrandThemed ? "" : "text-emerald-600")} fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" /></svg>,
-            bgClass: "bg-emerald-100",
-            buttonClass: isBrandThemed ? "text-white shadow-md hover:opacity-90 transition-opacity" : "bg-emerald-600 hover:bg-emerald-700 text-white shadow-md"
-        },
-        info: {
-            icon: <svg className={cn("w-6 h-6", isBrandThemed ? "" : "text-slate-700")} fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>,
-            bgClass: "bg-slate-100",
-            buttonClass: isBrandThemed ? "text-white shadow-md hover:opacity-90 transition-opacity" : "bg-slate-900 hover:bg-slate-800 text-white shadow-md"
-        }
-    };
+  // Dynamic configuration based on the tone
+  const toneConfig = {
+    error: {
+      icon: (
+        <svg
+          className="w-6 h-6 text-rose-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+      ),
+      bgClass: "bg-rose-100",
+      buttonClass: "bg-rose-600 hover:bg-rose-700 text-white shadow-md",
+    },
+    warning: {
+      icon: (
+        <svg
+          className="w-6 h-6 text-amber-600"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+      bgClass: "bg-amber-100",
+      buttonClass: "bg-amber-500 hover:bg-amber-600 text-white shadow-md",
+    },
+    success: {
+      icon: (
+        <svg
+          className={cn("w-6 h-6", isBrandThemed ? "" : "text-emerald-600")}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      ),
+      bgClass: "bg-emerald-100",
+      buttonClass: isBrandThemed
+        ? "text-white shadow-md hover:opacity-90 transition-opacity"
+        : "bg-emerald-600 hover:bg-emerald-700 text-white shadow-md",
+    },
+    info: {
+      icon: (
+        <svg
+          className={cn("w-6 h-6", isBrandThemed ? "" : "text-slate-700")}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2.5}
+            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      ),
+      bgClass: "bg-slate-100",
+      buttonClass: isBrandThemed
+        ? "text-white shadow-md hover:opacity-90 transition-opacity"
+        : "bg-slate-900 hover:bg-slate-800 text-white shadow-md",
+    },
+  };
 
-    const config = toneConfig[tone];
+  const config = toneConfig[tone];
 
-    const handleConfirm = () => {
-        if (onConfirm) onConfirm();
-        onClose();
-    };
+  const handleConfirm = () => {
+    if (onConfirm) onConfirm();
+    onClose();
+  };
 
-    return (
-        <div className="fixed inset-0 z-[200] flex items-center justify-center p-4 sm:p-6">
-            <div
-                className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-300"
-                onClick={onClose}
-            />
+  return (
+    <div className="fixed inset-0 z-200 flex items-center justify-center p-4 sm:p-6">
+      <div
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-300"
+        onClick={onClose}
+      />
 
-            <div className="relative bg-white rounded-3xl shadow-2xl w-full max-w-md overflow-hidden flex flex-col border border-slate-100 animate-in fade-in zoom-in-75 slide-in-from-bottom-8 duration-300 ease-out">
-                <div className="p-6 sm:p-8 text-center sm:text-left sm:flex sm:items-start sm:gap-5">
+      <div className="relative bg-white rounded-3xl shadow-2xl w-full max-w-md overflow-hidden flex flex-col border border-slate-100 animate-in fade-in zoom-in-75 slide-in-from-bottom-8 duration-300 ease-out">
+        <div className="p-6 sm:p-8 text-center sm:text-left sm:flex sm:items-start sm:gap-5">
+          <div
+            className={cn(
+              "mx-auto sm:mx-0 flex items-center justify-center shrink-0 w-14 h-14 rounded-full mb-5 sm:mb-0 shadow-sm border border-white",
+              !isBrandThemed && config.bgClass,
+            )}
+            style={
+              isBrandThemed
+                ? {
+                    color: primaryColor,
+                    backgroundColor: `${primaryColor}1A`,
+                  }
+                : {}
+            }
+          >
+            {config.icon}
+          </div>
 
-                    <div
-                        className={cn("mx-auto sm:mx-0 flex items-center justify-center shrink-0 w-14 h-14 rounded-full mb-5 sm:mb-0 shadow-sm border border-white", !isBrandThemed && config.bgClass)}
-                        style={isBrandThemed ? {
-                            color: primaryColor,
-                            backgroundColor: `${primaryColor}1A`
-                        } : {}}
-                    >
-                        {config.icon}
-                    </div>
-
-                    {/* Text Content */}
-                    <div className="flex-1 mt-1">
-                        <h3 className="text-xl font-bold text-slate-900 mb-2 font-[family:var(--font-heading)] leading-tight">
-                            {title}
-                        </h3>
-                        <p className="text-sm text-slate-600 leading-relaxed">
-                            {message}
-                        </p>
-                    </div>
-                </div>
-
-                {/* Footer Actions */}
-                <div className="px-6 py-5 bg-slate-50 border-t border-slate-100 flex flex-col-reverse sm:flex-row sm:justify-end gap-3 flex-wrap">
-                    {showCancel && (
-                        <button
-                            type="button"
-                            onClick={onClose}
-                            className="px-5 py-2.5 rounded-xl text-sm font-semibold text-slate-600 hover:bg-slate-200 transition-colors w-full sm:w-auto"
-                        >
-                            {cancelText}
-                        </button>
-                    )}
-                    {actions ? (
-                        actions.map((action, i) => (
-                            <button
-                                key={i}
-                                type="button"
-                                onClick={() => { action.onClick(); onClose(); }}
-                                className={cn("px-6 py-2.5 rounded-xl text-sm font-bold w-full sm:w-auto transition-colors", action.isPrimary ? config.buttonClass : "bg-white border border-slate-200 text-slate-700 hover:bg-slate-50")}
-                                style={action.isPrimary && isBrandThemed ? { backgroundColor: primaryColor } : {}}
-                            >
-                                {action.label}
-                            </button>
-                        ))
-                    ) : (
-                        <button
-                            type="button"
-                            onClick={handleConfirm}
-                            className={cn("px-6 py-2.5 rounded-xl text-sm font-bold w-full sm:w-auto", config.buttonClass)}
-                            style={isBrandThemed ? { backgroundColor: primaryColor } : {}}
-                        >
-                            {confirmText}
-                        </button>
-                    )}
-                </div>
-            </div>
+          {/* Text Content */}
+          <div className="flex-1 mt-1">
+            <h3 className="text-xl font-bold text-slate-900 mb-2 font-[family:var(--font-heading)] leading-tight">
+              {title}
+            </h3>
+            <p className="text-sm text-slate-600 leading-relaxed">{message}</p>
+          </div>
         </div>
-    );
+
+        {/* Footer Actions */}
+        <div className="px-6 py-5 bg-slate-50 border-t border-slate-100 flex flex-col-reverse sm:flex-row sm:justify-end gap-3 flex-wrap">
+          {showCancel && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-5 py-2.5 rounded-xl text-sm font-semibold text-slate-600 hover:bg-slate-200 transition-colors w-full sm:w-auto"
+            >
+              {cancelText}
+            </button>
+          )}
+          {actions ? (
+            actions.map((action, i) => (
+              <button
+                key={i}
+                type="button"
+                onClick={() => {
+                  action.onClick();
+                  onClose();
+                }}
+                className={cn(
+                  "px-6 py-2.5 rounded-xl text-sm font-bold w-full sm:w-auto transition-colors",
+                  action.isPrimary
+                    ? config.buttonClass
+                    : "bg-white border border-slate-200 text-slate-700 hover:bg-slate-50",
+                )}
+                style={
+                  action.isPrimary && isBrandThemed
+                    ? { backgroundColor: primaryColor }
+                    : {}
+                }
+              >
+                {action.label}
+              </button>
+            ))
+          ) : (
+            <button
+              type="button"
+              onClick={handleConfirm}
+              className={cn(
+                "px-6 py-2.5 rounded-xl text-sm font-bold w-full sm:w-auto",
+                config.buttonClass,
+              )}
+              style={isBrandThemed ? { backgroundColor: primaryColor } : {}}
+            >
+              {confirmText}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/templates/authenticated-shell.tsx
+++ b/src/components/templates/authenticated-shell.tsx
@@ -75,8 +75,24 @@ export function AuthenticatedShell({
       ? isTemporaryApplicant
       : temporaryApplicantFromContext;
 
+  const themeStyles = tenantBranding
+    ? ({
+        "--primary": tenantBranding.primaryColor,
+        "--color-primary": tenantBranding.primaryColor,
+        ...(tenantBranding.fontFamily
+          ? {
+              "--font-heading": tenantBranding.fontFamily,
+              "--font-body": tenantBranding.fontFamily,
+            }
+          : {}),
+      } as React.CSSProperties)
+    : undefined;
+
   return (
-    <div className="flex w-full h-dvh overflow-hidden bg-slate-50">
+    <div
+      className="flex w-full h-dvh overflow-hidden bg-slate-50"
+      style={themeStyles}
+    >
       <SidebarNav
         isTemporaryApplicant={temporaryApplicant}
         onSignOut={signOut}

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 
 import {
@@ -522,6 +523,8 @@ export async function updateProfileAction(
 
   // Refresh session so the new metadata is reflected immediately
   await supabase.auth.refreshSession();
+
+  revalidatePath("/", "layout");
 
   return { success: "Profile updated successfully." };
 }

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -423,3 +423,119 @@ export async function signOut() {
 
   redirect("/login");
 }
+
+export type UpdateProfileActionState = {
+  error?: string;
+  success?: string;
+};
+
+const updateProfileSchema = z.object({
+  displayName: z.string().min(1, "Display name is required"),
+  avatarUrl: z.string().url("Must be a valid URL").optional().or(z.literal("")),
+});
+
+export async function updateProfileAction(
+  _prevState: UpdateProfileActionState,
+  formData: FormData
+): Promise<UpdateProfileActionState> {
+  const displayName = String(formData.get("displayName") ?? "").trim();
+  const avatarUrlRaw = formData.get("avatarUrl");
+  const avatarUrl = avatarUrlRaw ? String(avatarUrlRaw).trim() : undefined;
+
+  const parsed = updateProfileSchema.safeParse({ displayName, avatarUrl });
+
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0].message };
+  }
+
+  const supabase = await createUserClient(LOCAL_COOKIE_DOMAIN);
+  if (!supabase) return { error: "Supabase auth environment is not configured." };
+
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  
+  if (userError || !user) {
+    return { error: "You must be logged in to update your profile." };
+  }
+
+  const adminClient = createSupabaseAdminClient("update-profile");
+  if (!adminClient) {
+    return { error: "Admin client not configured." };
+  }
+
+  const currentMetadata = getCurrentUserMetadata(user);
+  
+  const { error: updateError } = await adminClient.auth.admin.updateUserById(
+    user.id,
+    {
+      user_metadata: {
+        ...currentMetadata,
+        display_name: parsed.data.displayName,
+        avatar_url: parsed.data.avatarUrl,
+      }
+    }
+  );
+
+  if (updateError) {
+    return { error: updateError.message };
+  }
+
+  // Refresh session so the new metadata is reflected immediately
+  await supabase.auth.refreshSession();
+
+  return { success: "Profile updated successfully." };
+}
+
+export type ChangePasswordActionState = {
+  error?: string;
+  success?: string;
+};
+
+const changePasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(
+        AUTH_PASSWORD_MIN_LENGTH,
+        `Minimum ${AUTH_PASSWORD_MIN_LENGTH} characters.`
+      )
+      .regex(AUTH_PASSWORD_REQUIREMENTS_PATTERN, AUTH_PASSWORD_HELP_TEXT),
+    confirmPassword: z.string().min(1, "Please confirm your password."),
+  })
+  .superRefine((value, ctx) => {
+    if (value.confirmPassword !== value.newPassword) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Passwords do not match.",
+        path: ["confirmPassword"],
+      });
+    }
+  });
+
+export async function changePasswordAction(
+  _prevState: ChangePasswordActionState,
+  formData: FormData
+): Promise<ChangePasswordActionState> {
+  const newPassword = String(formData.get("newPassword") ?? "");
+  const confirmPassword = String(formData.get("confirmPassword") ?? "");
+
+  const parsed = changePasswordSchema.safeParse({ newPassword, confirmPassword });
+
+  if (!parsed.success) {
+    return { 
+      error: parsed.error.issues[0].message,
+    };
+  }
+
+  const supabase = await createUserClient(LOCAL_COOKIE_DOMAIN);
+  if (!supabase) return { error: "Supabase auth environment is not configured." };
+
+  const { error: updateError } = await supabase.auth.updateUser({
+    password: parsed.data.newPassword
+  });
+
+  if (updateError) {
+    return { error: updateError.message };
+  }
+
+  return { success: "Password changed successfully." };
+}

--- a/src/lib/actions/organization-settings.ts
+++ b/src/lib/actions/organization-settings.ts
@@ -2,8 +2,11 @@
 
 import { createClient } from '@supabase/supabase-js';
 
+import { redirect } from 'next/navigation';
+import { revalidatePath } from 'next/cache';
 import { getCurrentViewer, resolveCurrentTenant } from '@/lib/supabase/server';
 import { RESERVED_SUBDOMAINS } from '@/lib/reserved-subdomains';
+import { getTenantAppUrl } from '@/lib/root-domain';
 
 export type OrganizationSettingsState = {
     error?: string;
@@ -149,6 +152,13 @@ export async function updateOrganizationSettings(
     if (error) {
         return { error: error.message };
     }
+
+    if (updatePayload.slug) {
+        // Slug changed, redirect to the new domain
+        redirect(`${await getTenantAppUrl(updatePayload.slug as string)}/admin/settings`);
+    }
+
+    revalidatePath('/', 'layout');
 
     return { success: 'Organization settings saved.' };
 }

--- a/src/lib/navigation-config.tsx
+++ b/src/lib/navigation-config.tsx
@@ -293,13 +293,8 @@ const ROLE_ROUTE_SLUGS: Record<UserRole, RouteSlug[]> = {
     "roles",
     "settings",
   ],
-<<<<<<< HEAD
-  Officer: ["feed", "members", "attendance", "recruitment", "events"],
-  Member: ["feed", "applications", "events", "id", "settings"],
-=======
   Officer: ["feed", "members"],
   Member: ["feed", "applications", "events", "id"],
->>>>>>> origin
 };
 
 function getRolePath(role: UserRole) {

--- a/src/lib/navigation-config.tsx
+++ b/src/lib/navigation-config.tsx
@@ -294,7 +294,7 @@ const ROLE_ROUTE_SLUGS: Record<UserRole, RouteSlug[]> = {
     "settings",
   ],
   Officer: ["feed", "members"],
-  Member: ["feed", "applications", "events", "id"],
+  Member: ["feed", "applications", "events", "id", "settings"],
 };
 
 function getRolePath(role: UserRole) {

--- a/src/lib/navigation-config.tsx
+++ b/src/lib/navigation-config.tsx
@@ -204,7 +204,7 @@ const NAV_ITEM_DEFINITIONS: Array<{
   {
     label: "Settings",
     slug: "settings",
-    visibleTo: ["Owner", "Admin", "Officer"],
+    visibleTo: ["Owner", "Admin", "Officer", "Member"],
     icon: (
       <IconWrapper>
         <path
@@ -294,7 +294,7 @@ const ROLE_ROUTE_SLUGS: Record<UserRole, RouteSlug[]> = {
     "settings",
   ],
   Officer: ["feed", "members", "attendance", "recruitment", "events"],
-  Member: ["feed", "applications", "events", "id"],
+  Member: ["feed", "applications", "events", "id", "settings"],
 };
 
 function getRolePath(role: UserRole) {

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -33,6 +33,8 @@ export type ViewerContext = {
   tenantRole: string | null;
   tenantId: string | null;
   tenantSlug: string | null;
+  displayName: string | null;
+  avatarUrl: string | null;
 };
 
 export type TenantContext = {
@@ -232,6 +234,16 @@ export const getCurrentViewer = cache(async (): Promise<ViewerContext | null> =>
           : typeof user.app_metadata?.tenant_slug === "string"
             ? user.app_metadata.tenant_slug
             : null,
+      displayName:
+        typeof userMetadata?.display_name === "string" && userMetadata.display_name
+          ? userMetadata.display_name
+          : typeof userMetadata?.full_name === "string" && userMetadata.full_name
+            ? userMetadata.full_name
+            : null,
+      avatarUrl:
+        typeof userMetadata?.avatar_url === "string" && userMetadata.avatar_url
+          ? userMetadata.avatar_url
+          : null,
     };
   } catch (error) {
     if (isInvalidRefreshTokenError(error)) {


### PR DESCRIPTION
This PR introduces a dedicated settings page for Members, allowing them to manage their personal profile, notifications, and password. Along with this feature, a bug was fixed where the global shell (top bar and sidebar) was completely ignoring the user's saved display name.

Changes Included:

Navigation: Updated navigation-config.tsx to expose the /member/settings route to Members.
Server Actions: Added updateProfileAction (admin client) and changePasswordAction (user client) to auth.ts.
Settings UI: Created the Settings page utilizing existing atom components (Input, Button, Switch).
Profile: Users can update their display name and provide an avatar URL.
Preferences: Added a client-side toggle for email notifications (persisted to localStorage for v1).
Security: Added a password change form that enforces the existing password complexity requirements.
Display Name Fix:
Updated getCurrentViewer() in server.ts to pull display_name, full_name, and avatar_url from user_metadata and attach them to ViewerContext.
Updated the admin, member, officer, and superadmin layout files to pass viewer.displayName down to AuthenticatedShell rather than hardcoding the prefix of the user's email address.
Testing Notes:

Log in as a Member and verify that "Settings" appears in the sidebar.
Test changing your display name; verify that saving works and immediately reflects in the top-right corner and bottom-left sidebar upon navigation/reload.
Toggle the Email Notifications switch and refresh the page to verify it persists via local storage.
Test changing the password and logging back in.
npm run lint and npm run typecheck have both been run and pass cleanly.