### PR TITLE
feat(announcements): implement official members announcements board (…

### DIFF
--- a/src/app/admin/feed/page.tsx
+++ b/src/app/admin/feed/page.tsx
@@ -1,144 +1,50 @@
-"use client";
+import {
+  getAnnouncements,
+  acknowledgeAnnouncement,
+} from "@/lib/actions/announcements";
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import {
+  AnnouncementsBoard,
+  type Announcement,
+} from "@/components/organisms/announcements-board";
+import { CreateAnnouncementForm } from "@/components/organisms/create-announcement-form";
+import { notFound } from "next/navigation";
 
-import { useState } from "react";
-import { Button } from "@/components/atoms/button";
+export const metadata = {
+  title: "Feed | Salina",
+};
 
-interface Post {
-  id: number;
-  content: string;
-  author: string;
-  timestamp: string;
-  likes: number;
-  replies: number;
-}
+export default async function AdminFeedPage() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
 
-const INITIAL_POSTS: Post[] = [
-  {
-    id: 1,
-    content:
-      "Welcome to the new semester! Recruitment opens next Monday. Prepare your applications.",
-    author: "Admin",
-    timestamp: "2 hours ago",
-    likes: 24,
-    replies: 8,
-  },
-  {
-    id: 2,
-    content:
-      "General Assembly this Friday at 6PM in the Main Hall. Attendance is mandatory.",
-    author: "Admin",
-    timestamp: "Yesterday",
-    likes: 31,
-    replies: 12,
-  },
-  {
-    id: 3,
-    content:
-      "Congratulations to all new members who passed the deliberation stage!",
-    author: "Admin",
-    timestamp: "3 days ago",
-    likes: 47,
-    replies: 15,
-  },
-];
-
-export default function FeedPage() {
-  const [postContent, setPostContent] = useState("");
-  const [posts, setPosts] = useState<Post[]>(INITIAL_POSTS);
-
-  function handlePost() {
-    const trimmed = postContent.trim();
-    if (!trimmed) return;
-    setPosts((prev) => [
-      {
-        id: Date.now(),
-        content: trimmed,
-        author: "Admin",
-        timestamp: "Just now",
-        likes: 0,
-        replies: 0,
-      },
-      ...prev,
-    ]);
-    setPostContent("");
+  if (!tenant || !viewer) {
+    notFound();
   }
 
+  const announcements = await getAnnouncements();
+
   return (
-    <div style={{ fontFamily: "var(--font-body)" }}>
-      {/* Header */}
-      <h1
-        className="text-3xl font-bold tracking-tight text-foreground"
-        style={{ fontFamily: "var(--font-heading)" }}
-      >
-        Organization Feed
-      </h1>
-      <p className="mt-1 text-base text-slate-500">
-        Broadcast announcements to your organization.
-      </p>
-
-      {/* Post composer */}
-      <div className="mt-6 rounded-2xl border border-border bg-white p-6 shadow-sm">
-        <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-slate-500">
-          New Announcement
+    <div className="w-full max-w-4xl mx-auto py-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="mb-8 space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-neutral-100">
+          Organization Feed
+        </h1>
+        <p className="text-neutral-500 dark:text-neutral-400">
+          Post and track official announcements for {tenant.name}.
         </p>
-
-        <textarea
-          rows={4}
-          placeholder="Write an announcement..."
-          value={postContent}
-          onChange={(e) => setPostContent(e.target.value)}
-          className="w-full resize-none rounded-[var(--radius)] border border-border p-3 text-sm text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/10 placeholder:text-slate-400"
-        />
-
-        <div className="mt-3 flex items-center justify-between">
-          <p className="text-xs text-slate-500">Visible to all members</p>
-          <Button onClick={handlePost}>Post Announcement</Button>
-        </div>
       </div>
 
-      {/* Feed posts */}
-      <div className="mt-8 space-y-4">
-        {posts.map((post) => (
-          <div
-            key={post.id}
-            className="rounded-2xl border border-border bg-white p-6 shadow-sm"
-          >
-            {/* Top row */}
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-3">
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-bold text-primary">
-                  A
-                </div>
-                <div>
-                  <p className="text-sm font-semibold text-foreground">
-                    {post.author}
-                  </p>
-                  <p className="text-xs text-slate-500">{post.timestamp}</p>
-                </div>
-              </div>
-              <button
-                type="button"
-                className="text-slate-400 transition-colors hover:text-foreground"
-              >
-                ⋯
-              </button>
-            </div>
+      <CreateAnnouncementForm />
 
-            {/* Content */}
-            <p className="mt-3 text-sm leading-relaxed text-foreground">
-              {post.content}
-            </p>
-
-            {/* Reactions */}
-            <div className="mt-4 flex gap-4 border-t border-border pt-4">
-              <span className="text-xs text-slate-500">👍 {post.likes}</span>
-              <span className="text-xs text-slate-500">
-                💬 {post.replies} replies
-              </span>
-            </div>
-          </div>
-        ))}
-      </div>
+      <h2 className="mb-4 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        Posted Announcements
+      </h2>
+      <AnnouncementsBoard
+        announcements={announcements as Announcement[]}
+        onAcknowledge={acknowledgeAnnouncement}
+        isOfficerOrAdmin={true}
+      />
     </div>
   );
 }

--- a/src/app/member/feed/page.tsx
+++ b/src/app/member/feed/page.tsx
@@ -1,28 +1,45 @@
-import { OrganizationFeed } from "@/components/organisms/organization-feed";
+import {
+  getAnnouncements,
+  acknowledgeAnnouncement,
+} from "@/lib/actions/announcements";
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import {
+  AnnouncementsBoard,
+  type Announcement,
+} from "@/components/organisms/announcements-board";
+import { notFound } from "next/navigation";
 
-const feedPosts = [
-  {
-    title: "Weekend outreach schedule confirmed",
-    category: "Operations",
-    author: "Secretariat Office",
-    time: "12 minutes ago",
-    body: "The outreach team will gather at 7:30 AM on Saturday. Logistics, name tags, and transportation are already locked in.",
-    stats: "17 reads · 4 acknowledgements",
-  },
-  {
-    title: "Attendance sheet updated for the annual assembly",
-    category: "Attendance",
-    author: "Attendance Committee",
-    time: "Today at 8:15 AM",
-    body: "The QR check-in link has been regenerated and the backup manual list is ready at the registration desk.",
-    stats: "23 reads · 6 confirmations",
-  },
-];
+export const metadata = {
+  title: "Feed | Salina",
+};
 
-export default function MemberFeedPage() {
+export default async function MemberFeedPage() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+
+  if (!tenant || !viewer) {
+    notFound();
+  }
+
+  const announcements = await getAnnouncements();
+
   return (
-    <div className="py-8">
-      <OrganizationFeed posts={feedPosts} canPost={false} />
+    <div className="w-full max-w-4xl mx-auto py-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="mb-8 space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-neutral-100">
+          Organization Feed
+        </h1>
+        <p className="text-neutral-500 dark:text-neutral-400">
+          Stay updated with the latest official announcements from {tenant.name}
+          .
+        </p>
+      </div>
+
+      <AnnouncementsBoard
+        announcements={announcements as Announcement[]}
+        onAcknowledge={acknowledgeAnnouncement}
+        isOfficerOrAdmin={false}
+      />
     </div>
   );
 }

--- a/src/app/officer/feed/page.tsx
+++ b/src/app/officer/feed/page.tsx
@@ -1,189 +1,50 @@
-import { Badge } from "@/components/atoms/badge";
-import { Button } from "@/components/atoms/button";
-import { Input } from "@/components/atoms/input";
-import { TextField } from "@/components/molecules/text-field";
-import { StatusBanner } from "@/components/molecules/status-banner";
+import {
+  getAnnouncements,
+  acknowledgeAnnouncement,
+} from "@/lib/actions/announcements";
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import {
+  AnnouncementsBoard,
+  type Announcement,
+} from "@/components/organisms/announcements-board";
+import { CreateAnnouncementForm } from "@/components/organisms/create-announcement-form";
+import { notFound } from "next/navigation";
 
-const audienceTags = ["Officers", "Members", "Advisers"];
+export const metadata = {
+  title: "Feed | Salina",
+};
 
-const feedPosts = [
-  {
-    title: "Weekend outreach schedule confirmed",
-    category: "Operations",
-    author: "Secretariat Office",
-    time: "12 minutes ago",
-    body: "The outreach team will gather at 7:30 AM on Saturday. Logistics, name tags, and transportation are already locked in.",
-    stats: "17 reads · 4 acknowledgements",
-  },
-  {
-    title: "Recruitment interview panel needs one more reviewer",
-    category: "Recruitment",
-    author: "Vice President for External",
-    time: "1 hour ago",
-    body: "Please react to the thread if you can sit in on the final round. The newest applicant batch is ready for officer scoring.",
-    stats: "9 reads · 2 replies",
-  },
-  {
-    title: "Attendance sheet updated for the annual assembly",
-    category: "Attendance",
-    author: "Attendance Committee",
-    time: "Today at 8:15 AM",
-    body: "The QR check-in link has been regenerated and the backup manual list is ready at the registration desk.",
-    stats: "23 reads · 6 confirmations",
-  },
-];
+export default async function OfficerFeedPage() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
 
-export default function OfficerFeedPage() {
+  if (!tenant || !viewer) {
+    notFound();
+  }
+
+  const announcements = await getAnnouncements();
+
   return (
-    <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-8">
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.75fr)]">
-        <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm lg:p-7">
-          <Badge className="bg-[var(--primary)] text-white">
-            Announcement feed
-          </Badge>
-          <h2 className="mt-4 text-3xl font-bold tracking-tight text-slate-900 font-[family:var(--font-heading)]">
-            Publish organization updates
-          </h2>
-          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-500">
-            Share officer directives, event reminders, and recruitment notes
-            without leaving the command center.
-          </p>
+    <div className="w-full max-w-4xl mx-auto py-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+      <div className="mb-8 space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight text-neutral-900 dark:text-neutral-100">
+          Organization Feed
+        </h1>
+        <p className="text-neutral-500 dark:text-neutral-400">
+          Post and track official announcements for {tenant.name}.
+        </p>
+      </div>
 
-          <div className="mt-6 grid gap-4">
-            <TextField
-              id="announcement-title"
-              label="Headline"
-              placeholder="Ex: Attendance opens at 4:30 PM"
-              helperText="Keep the title short and action-oriented."
-            />
+      <CreateAnnouncementForm />
 
-            <div>
-              <label
-                htmlFor="announcement-body"
-                className="block text-xs font-medium uppercase tracking-[0.06em] text-[#6B7280]"
-              >
-                Message
-              </label>
-              <textarea
-                id="announcement-body"
-                rows={6}
-                className="mt-1 block w-full rounded-[var(--radius)] border-[1.5px] border-[#E5E7EB] bg-[#F9FAFB] px-3.5 py-3 text-sm text-foreground outline-none transition duration-200 placeholder:text-slate-400 focus:border-primary focus:bg-white focus:ring-4 focus:ring-primary/10"
-                placeholder="Write the announcement body here."
-                defaultValue="Attendance opens at 4:30 PM. Please review the check-in queue and keep the event desk clear for guests."
-              />
-            </div>
-
-            <Input
-              placeholder="Add a reference tag, like #attendance or #events"
-              aria-label="Announcement tag"
-            />
-          </div>
-
-          <div className="mt-5 flex flex-wrap gap-2">
-            {audienceTags.map((tag) => (
-              <Badge
-                key={tag}
-                className="border border-[var(--primary)]/20 bg-[var(--primary)]/10 text-[var(--primary)]"
-              >
-                {tag}
-              </Badge>
-            ))}
-          </div>
-
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <StatusBanner tone="info" className="border-slate-200 bg-slate-50">
-              Drafts stay private until you publish them to the officer feed.
-            </StatusBanner>
-
-            <div className="flex gap-3">
-              <Button variant="secondary">Save draft</Button>
-              <Button variant="dark">Publish update</Button>
-            </div>
-          </div>
-        </article>
-
-        <aside className="space-y-6">
-          <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-900">
-              Posting controls
-            </h3>
-            <div className="mt-5 space-y-3">
-              <div className="rounded-2xl bg-slate-50 p-4">
-                <p className="text-sm font-medium text-slate-500">Audience</p>
-                <p className="mt-2 text-base font-semibold text-slate-900">
-                  Officers and members
-                </p>
-              </div>
-              <div className="rounded-2xl bg-slate-50 p-4">
-                <p className="text-sm font-medium text-slate-500">
-                  Draft queue
-                </p>
-                <p className="mt-2 text-base font-semibold text-slate-900">
-                  3 posts awaiting approval
-                </p>
-              </div>
-              <div className="rounded-2xl bg-slate-50 p-4">
-                <p className="text-sm font-medium text-slate-500">
-                  Pinned notices
-                </p>
-                <p className="mt-2 text-base font-semibold text-slate-900">
-                  2 active notices on top of the feed
-                </p>
-              </div>
-            </div>
-          </article>
-
-          <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-slate-900">Feed rules</h3>
-            <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-600">
-              <li>• Keep posts concise and action-focused.</li>
-              <li>
-                • Tag attendance or event posts so officers can filter quickly.
-              </li>
-              <li>
-                • Use the draft queue when a message still needs approval.
-              </li>
-            </ul>
-          </article>
-        </aside>
-      </section>
-
-      <section className="space-y-4">
-        {feedPosts.map((post) => (
-          <article
-            key={post.title}
-            className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
-          >
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <Badge className="bg-slate-900 text-white">
-                  {post.category}
-                </Badge>
-                <h3 className="mt-3 text-xl font-semibold text-slate-900">
-                  {post.title}
-                </h3>
-                <p className="mt-2 text-sm text-slate-500">{post.author}</p>
-              </div>
-
-              <span className="text-xs font-medium uppercase tracking-[0.22em] text-slate-400">
-                {post.time}
-              </span>
-            </div>
-
-            <p className="mt-4 max-w-4xl text-sm leading-6 text-slate-600">
-              {post.body}
-            </p>
-
-            <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-slate-500">{post.stats}</p>
-              <div className="flex gap-3">
-                <Button variant="secondary">Reply</Button>
-                <Button variant="secondary">Boost</Button>
-              </div>
-            </div>
-          </article>
-        ))}
-      </section>
+      <h2 className="mb-4 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+        Posted Announcements
+      </h2>
+      <AnnouncementsBoard
+        announcements={announcements as Announcement[]}
+        onAcknowledge={acknowledgeAnnouncement}
+        isOfficerOrAdmin={true}
+      />
     </div>
   );
 }

--- a/src/components/organisms/announcements-board.tsx
+++ b/src/components/organisms/announcements-board.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/atoms/button";
+import { Badge } from "@/components/atoms/badge";
+
+export interface Announcement {
+  id: string;
+  title: string;
+  body: string;
+  category: string;
+  created_at: string;
+  author: {
+    id: string;
+    email: string;
+    raw_user_meta_data?: {
+      full_name?: string;
+    };
+  };
+  acknowledgmentCount: number;
+  hasAcknowledged: boolean;
+}
+
+interface AnnouncementsBoardProps {
+  announcements: Announcement[];
+  onAcknowledge: (id: string) => Promise<unknown>;
+  isOfficerOrAdmin: boolean;
+}
+
+export function AnnouncementsBoard({
+  announcements,
+  onAcknowledge,
+  isOfficerOrAdmin,
+}: AnnouncementsBoardProps) {
+  const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+
+  const handleAcknowledge = async (id: string) => {
+    setLoadingIds((prev) => new Set(prev).add(id));
+    try {
+      await onAcknowledge(id);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }
+  };
+
+  if (announcements.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8 text-center border rounded-2xl border-border bg-white shadow-sm">
+        <p className="text-sm text-slate-500">No official announcements yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {announcements.map((announcement) => {
+        const authorName =
+          announcement.author.raw_user_meta_data?.full_name ||
+          announcement.author.email;
+        const dateStr = new Date(announcement.created_at).toLocaleDateString(
+          undefined,
+          {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          },
+        );
+
+        return (
+          <div
+            key={announcement.id}
+            className={`flex flex-col p-6 border rounded-2xl shadow-sm transition-colors ${
+              announcement.hasAcknowledged
+                ? "bg-white border-border"
+                : "bg-primary/5 border-primary/20"
+            }`}
+          >
+            <div className="flex items-start justify-between mb-4">
+              <div>
+                <div className="flex items-center gap-2 mb-2">
+                  <Badge
+                    variant={
+                      announcement.category === "Important"
+                        ? "destructive"
+                        : "default"
+                    }
+                  >
+                    {announcement.category}
+                  </Badge>
+                  <span className="text-xs text-slate-500">
+                    Posted on {dateStr} by {authorName}
+                  </span>
+                </div>
+                <h3 className="text-xl font-bold tracking-tight text-foreground">
+                  {announcement.title}
+                </h3>
+              </div>
+              {isOfficerOrAdmin && (
+                <div className="flex flex-col items-end text-sm">
+                  <span className="font-semibold text-foreground">
+                    {announcement.acknowledgmentCount}
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    Acknowledgments
+                  </span>
+                </div>
+              )}
+            </div>
+
+            <div className="mb-6 whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+              {announcement.body}
+            </div>
+
+            <div className="flex justify-end pt-4 border-t border-border">
+              {announcement.hasAcknowledged ? (
+                <div className="flex items-center gap-2 text-sm font-medium text-green-600">
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 6L9 17l-5-5" />
+                  </svg>
+                  Acknowledged
+                </div>
+              ) : (
+                <Button
+                  onClick={() => handleAcknowledge(announcement.id)}
+                  disabled={loadingIds.has(announcement.id)}
+                >
+                  {loadingIds.has(announcement.id)
+                    ? "Acknowledging..."
+                    : "Acknowledge"}
+                </Button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/organisms/create-announcement-form.tsx
+++ b/src/components/organisms/create-announcement-form.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React, { useState } from "react";
+import { Button } from "@/components/atoms/button";
+import { Input } from "@/components/atoms/input";
+import { Label } from "@/components/atoms/label";
+import { createAnnouncement } from "@/lib/actions/announcements";
+
+export function CreateAnnouncementForm() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+
+    const formData = new FormData(e.currentTarget);
+    const title = formData.get("title") as string;
+    const body = formData.get("body") as string;
+    const category = formData.get("category") as string;
+
+    try {
+      await createAnnouncement({ title, body, category });
+      (e.target as HTMLFormElement).reset();
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Failed to create announcement");
+      } else {
+        setError("Failed to create announcement");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-6 p-6 mb-8 rounded-2xl border border-border bg-white shadow-sm"
+    >
+      <h2 className="mb-4 text-xs font-semibold uppercase tracking-widest text-slate-500">
+        Post New Announcement
+      </h2>
+
+      {error && (
+        <div className="p-3 mb-4 text-sm text-red-600 rounded bg-red-50">
+          {error}
+        </div>
+      )}
+
+      <div className="space-y-4">
+        <div>
+          <Label htmlFor="title">Title</Label>
+          <Input
+            id="title"
+            name="title"
+            required
+            placeholder="Announcement Title"
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="category">Category</Label>
+          <select
+            id="category"
+            name="category"
+            required
+            className="flex w-full h-10 px-3 py-2 text-sm bg-transparent rounded-[var(--radius)] border border-border outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/10 disabled:cursor-not-allowed disabled:opacity-50 text-foreground"
+          >
+            <option value="General">General</option>
+            <option value="Important">Important</option>
+            <option value="Event">Event</option>
+            <option value="Reminder">Reminder</option>
+          </select>
+        </div>
+
+        <div>
+          <Label htmlFor="body">Message Body</Label>
+          <textarea
+            id="body"
+            name="body"
+            required
+            rows={4}
+            placeholder="Type your announcement here..."
+            className="w-full resize-none rounded-[var(--radius)] border border-border p-3 text-sm text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/10 placeholder:text-slate-400"
+          ></textarea>
+        </div>
+
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? "Posting..." : "Post Announcement"}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/actions/announcements.ts
+++ b/src/lib/actions/announcements.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { resolveCurrentTenant, getCurrentViewer, createSupabaseUserClient } from "@/lib/supabase/server";
+import { canManageAnnouncements } from "@/lib/organization-permissions";
+import { z } from "zod";
+
+const createAnnouncementSchema = z.object({
+  title: z.string().min(1),
+  body: z.string().min(1),
+  category: z.string().min(1),
+});
+
+export async function createAnnouncement(rawInput: unknown) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const userClient = await createSupabaseUserClient();
+
+  if (!tenant || !userClient || !viewer || !canManageAnnouncements(viewer)) {
+    throw new Error("You do not have permission to manage announcements.");
+  }
+
+  const input = createAnnouncementSchema.parse(rawInput);
+
+  const { data, error } = await userClient
+    .from("announcements")
+    .insert({
+      tenant_id: tenant.id,
+      author_user_id: viewer.id,
+      title: input.title,
+      body: input.body,
+      category: input.category,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(error.message);
+
+  revalidatePath(`/admin/feed`);
+  revalidatePath(`/officer/feed`);
+  revalidatePath(`/member/feed`);
+  return data;
+}
+
+export async function getAnnouncements() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const userClient = await createSupabaseUserClient();
+  const { createSupabaseAdminClient } = await import("@/lib/supabase/admin");
+  const adminClient = createSupabaseAdminClient("announcements-fetch");
+
+  if (!tenant || !userClient || !viewer || !adminClient) return [];
+
+  const { data: announcements, error } = await userClient
+    .from("announcements")
+    .select(`
+      *,
+      announcement_acknowledgments(user_id)
+    `)
+    .eq("tenant_id", tenant.id)
+    .order("created_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  const announcementsWithAuthors = await Promise.all(
+    announcements.map(async (announcement) => {
+      let authorName = "Unknown User";
+      let authorEmail = "";
+
+      if (announcement.author_user_id) {
+        const { data: userData, error: userError } = await adminClient.auth.admin.getUserById(announcement.author_user_id);
+        if (!userError && userData?.user) {
+          authorName = userData.user.user_metadata?.full_name || userData.user.user_metadata?.display_name || userData.user.email || authorName;
+          authorEmail = userData.user.email || "";
+        }
+      }
+
+      const acknowledgments = announcement.announcement_acknowledgments || [];
+      return {
+        ...announcement,
+        author: {
+           id: announcement.author_user_id,
+           email: authorEmail,
+           raw_user_meta_data: { full_name: authorName }
+        },
+        acknowledgmentCount: acknowledgments.length,
+        hasAcknowledged: acknowledgments.some((ack: { user_id: string }) => ack.user_id === viewer.id),
+      };
+    })
+  );
+
+  return announcementsWithAuthors;
+}
+
+export async function acknowledgeAnnouncement(announcementId: string) {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+  const userClient = await createSupabaseUserClient();
+
+  if (!tenant || !userClient || !viewer) {
+    throw new Error("You must be logged in to acknowledge announcements.");
+  }
+
+  const { error } = await userClient
+    .from("announcement_acknowledgments")
+    .insert({
+      tenant_id: tenant.id,
+      announcement_id: announcementId,
+      user_id: viewer.id,
+    });
+
+  if (error) {
+    // If it's a unique constraint violation, it's already acknowledged
+    if (error.code !== '23505') {
+      throw new Error(error.message);
+    }
+  }
+
+  revalidatePath(`/admin/feed`);
+  revalidatePath(`/officer/feed`);
+  revalidatePath(`/member/feed`);
+  return true;
+}

--- a/src/lib/organization-permissions.ts
+++ b/src/lib/organization-permissions.ts
@@ -81,3 +81,25 @@ export function canAssignTemporaryRoles(
     viewer.tenantRole === "admin"
   );
 }
+
+export function canManageAnnouncements(
+  viewer: TemporaryApplicantPermissionViewer | null | undefined
+) {
+  if (!viewer) {
+    return false;
+  }
+
+  if (viewer.isPlatformAdmin) {
+    return true;
+  }
+
+  if (viewer.customPermissions.includes("Announcement posting")) {
+    return true;
+  }
+
+  return (
+    viewer.tenantRole === "owner" ||
+    viewer.tenantRole === "admin" ||
+    viewer.tenantRole === "officer"
+  );
+}

--- a/supabase/migrations/20260526052817_add_announcements.sql
+++ b/supabase/migrations/20260526052817_add_announcements.sql
@@ -1,0 +1,71 @@
+create table public.announcements (
+  id uuid primary key default extensions.gen_random_uuid(),
+  tenant_id uuid not null references public.organizations(id) on delete cascade,
+  author_user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  body text not null,
+  category text not null,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table public.announcement_acknowledgments (
+  id uuid primary key default extensions.gen_random_uuid(),
+  tenant_id uuid not null references public.organizations(id) on delete cascade,
+  announcement_id uuid not null references public.announcements(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  acknowledged_at timestamptz not null default timezone('utc', now()),
+  unique(announcement_id, user_id)
+);
+
+-- Triggers for tenant scope
+create trigger enforce_tenant_scope_announcements
+  before insert or update or delete on public.announcements
+  for each row execute function public.enforce_tenant_scope();
+
+create trigger enforce_tenant_scope_announcement_acknowledgments
+  before insert or update or delete on public.announcement_acknowledgments
+  for each row execute function public.enforce_tenant_scope();
+
+-- Row level security
+alter table public.announcements enable row level security;
+alter table public.announcement_acknowledgments enable row level security;
+
+-- Policies for announcements
+create policy announcements_tenant_isolation_select
+  on public.announcements
+  for select
+  to authenticated
+  using (public.has_tenant_access(tenant_id));
+
+create policy announcements_tenant_isolation_insert
+  on public.announcements
+  for insert
+  to authenticated
+  with check (
+    public.has_tenant_access(tenant_id) and
+    exists (
+      select 1 from public.organization_memberships
+      where organization_memberships.tenant_id = announcements.tenant_id
+        and organization_memberships.user_id = auth.uid()
+        and organization_memberships.role in ('admin', 'owner', 'system_admin', 'officer')
+    )
+  );
+
+-- Policies for announcement_acknowledgments
+create policy announcement_acknowledgments_tenant_isolation_select
+  on public.announcement_acknowledgments
+  for select
+  to authenticated
+  using (public.has_tenant_access(tenant_id));
+
+create policy announcement_acknowledgments_tenant_isolation_insert
+  on public.announcement_acknowledgments
+  for insert
+  to authenticated
+  with check (
+    public.has_tenant_access(tenant_id) and
+    user_id = auth.uid()
+  );
+
+grant select, insert on public.announcements to authenticated, service_role;
+grant select, insert on public.announcement_acknowledgments to authenticated, service_role;


### PR DESCRIPTION
Description: Background / Context: Organizations need a formalized way to broadcast important information to their members and ensure it was received. This PR introduces an Official Announcements Board directly into the Feed tab. Officers and Admins can post official messages, and standard Members are prompted to "Acknowledge" them. This provides table-stakes read-receipt analytics for organization governance.

Key Changes:

Database layer: Created the announcements and announcement_acknowledgments tables. RLS is enforced (only officers/admins can insert, all authenticated members in the tenant can view).
Backend Actions: Added createAnnouncement, getAnnouncements, and acknowledgeAnnouncement actions. Replaced raw user queries with the supabase-admin client to safely fetch and attach author metadata to announcements.
UI Components:
CreateAnnouncementForm: Simple form for creating categorized announcements.
AnnouncementsBoard: Reusable list of announcements with acknowledgment states and counts.
Theming: Replaced hardcoded dark: variants with semantic CSS variables (bg-white, border-border, text-foreground, bg-primary) to fix legibility issues and seamlessly match the tenant's chosen dynamic theme.
Feed Integration: The Feed tab for Members, Officers, and Admins has been fully replaced with the live Announcements Board.
Testing Instructions:

Log in as an Officer/Admin and navigate to the Feed tab. Post a new announcement.
Log in as a normal Member in a separate browser and navigate to the Feed tab. Verify the form is hidden and click the "Acknowledge" button on the new announcement.
Refresh the Admin view to verify the Acknowledgment count increments accurately.