### PR TITLE
feat: dashboard for member and officer

### DIFF
--- a/src/app/member/dashboard/loading.tsx
+++ b/src/app/member/dashboard/loading.tsx
@@ -1,0 +1,63 @@
+import {
+  DashboardShell,
+  DashboardStatRow,
+  DashboardSection,
+} from "@/components/templates/dashboard-shell";
+
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-lg bg-slate-100" />
+        <div className="h-4 w-16 rounded-full bg-slate-100" />
+      </div>
+      <div className="mt-3 h-8 w-16 rounded bg-slate-100" />
+      <div className="mt-1.5 h-3 w-24 rounded bg-slate-50" />
+    </div>
+  );
+}
+
+function SkeletonSection() {
+  return (
+    <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 h-4 w-32 rounded bg-slate-100" />
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-3">
+            <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-slate-100" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-4 w-3/4 rounded bg-slate-100" />
+              <div className="h-3 w-full rounded bg-slate-50" />
+              <div className="h-2 w-16 rounded bg-slate-50" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardLoading() {
+  return (
+    <DashboardShell>
+      <DashboardStatRow>
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </DashboardStatRow>
+      <SkeletonSection />
+      <SkeletonSection />
+      <DashboardSection title="Quick Actions" fullWidth>
+        <div className="flex flex-wrap gap-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-10 w-36 animate-pulse rounded-lg bg-slate-100"
+            />
+          ))}
+        </div>
+      </DashboardSection>
+    </DashboardShell>
+  );
+}

--- a/src/app/member/dashboard/page.tsx
+++ b/src/app/member/dashboard/page.tsx
@@ -1,5 +1,37 @@
-import { ComingSoon } from "@/components/organisms/coming-soon";
+import { resolveCurrentTenant } from "@/lib/supabase/server";
+import { MemberDashboard } from "@/components/organisms/member-dashboard";
+import {
+  getDashboardStats,
+  getRecentActivity,
+  getUpcomingEvents,
+} from "@/lib/dashboard-queries";
 
-export default function MemberDashboardPage() {
-  return <ComingSoon moduleName="Member Dashboard" />;
+export default async function MemberDashboardPage() {
+  const { tenant } = await resolveCurrentTenant();
+
+  const [stats, recentActivity, upcomingEvents] = await Promise.all([
+    getDashboardStats(),
+    tenant ? getRecentActivity(tenant.id) : Promise.resolve([]),
+    tenant ? getUpcomingEvents(tenant.id) : Promise.resolve([]),
+  ]);
+
+  return (
+    <MemberDashboard
+      stats={stats}
+      recentActivity={recentActivity}
+      upcomingEvents={upcomingEvents}
+      tenantBranding={
+        tenant
+          ? {
+              name: tenant.name,
+              primaryColor:
+                tenant.themeConfig.primaryColor ?? "#c6623e",
+              textColor: "#ffffff",
+              logoUrl: tenant.themeConfig.logoUrl ?? undefined,
+              fontFamily: tenant.themeConfig.fontFamily ?? undefined,
+            }
+          : undefined
+      }
+    />
+  );
 }

--- a/src/app/officer/dashboard/loading.tsx
+++ b/src/app/officer/dashboard/loading.tsx
@@ -1,0 +1,65 @@
+import {
+  DashboardShell,
+  DashboardStatRow,
+  DashboardSection,
+} from "@/components/templates/dashboard-shell";
+
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-lg bg-slate-100" />
+        <div className="h-4 w-16 rounded-full bg-slate-100" />
+      </div>
+      <div className="mt-3 h-8 w-16 rounded bg-slate-100" />
+      <div className="mt-1.5 h-3 w-24 rounded bg-slate-50" />
+    </div>
+  );
+}
+
+function SkeletonSection() {
+  return (
+    <div className="animate-pulse rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="mb-4 h-4 w-32 rounded bg-slate-100" />
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="flex gap-3">
+            <div className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-slate-100" />
+            <div className="flex-1 space-y-1.5">
+              <div className="h-4 w-3/4 rounded bg-slate-100" />
+              <div className="h-3 w-full rounded bg-slate-50" />
+              <div className="h-2 w-16 rounded bg-slate-50" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardLoading() {
+  return (
+    <DashboardShell>
+      <DashboardStatRow>
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+        <SkeletonCard />
+      </DashboardStatRow>
+      <SkeletonSection />
+      <SkeletonSection />
+      <SkeletonSection />
+      <DashboardSection title="Quick Actions" fullWidth>
+        <div className="flex flex-wrap gap-3">
+          {[1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              className="h-10 w-36 animate-pulse rounded-lg bg-slate-100"
+            />
+          ))}
+        </div>
+      </DashboardSection>
+    </DashboardShell>
+  );
+}

--- a/src/app/officer/dashboard/page.tsx
+++ b/src/app/officer/dashboard/page.tsx
@@ -1,5 +1,43 @@
-import { ComingSoon } from "@/components/organisms/coming-soon";
+import { resolveCurrentTenant, getCurrentViewer } from "@/lib/supabase/server";
+import { OfficerDashboard } from "@/components/organisms/officer-dashboard";
+import {
+  getDashboardStats,
+  getRecentActivity,
+  getUpcomingEvents,
+  getMemberSummary,
+} from "@/lib/dashboard-queries";
 
-export default function OfficerDashboardPage() {
-  return <ComingSoon moduleName="Officer Dashboard" />;
+export default async function OfficerDashboardPage() {
+  const { tenant } = await resolveCurrentTenant();
+  const viewer = await getCurrentViewer();
+
+  const [stats, recentActivity, upcomingEvents, memberSummary] =
+    await Promise.all([
+      getDashboardStats(),
+      tenant ? getRecentActivity(tenant.id) : Promise.resolve([]),
+      tenant ? getUpcomingEvents(tenant.id) : Promise.resolve([]),
+      getMemberSummary(),
+    ]);
+
+  return (
+    <OfficerDashboard
+      stats={stats}
+      recentActivity={recentActivity}
+      upcomingEvents={upcomingEvents}
+      memberSummary={memberSummary}
+      customPermissions={viewer?.customPermissions ?? []}
+      tenantBranding={
+        tenant
+          ? {
+              name: tenant.name,
+              primaryColor:
+                tenant.themeConfig.primaryColor ?? "#c6623e",
+              textColor: "#ffffff",
+              logoUrl: tenant.themeConfig.logoUrl ?? undefined,
+              fontFamily: tenant.themeConfig.fontFamily ?? undefined,
+            }
+          : undefined
+      }
+    />
+  );
 }

--- a/src/components/molecules/stat-card.tsx
+++ b/src/components/molecules/stat-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type TrendDirection = "up" | "down" | "neutral";
+
+interface StatCardProps {
+  /** Icon element (SVG or component) */
+  icon: ReactNode;
+  /** Accent color for the icon background, e.g. "bg-primary/10 text-primary" */
+  iconClass?: string;
+  /** Label displayed below the value */
+  label: string;
+  /** The main numeric or text value */
+  value: string | number;
+  /** Optional trend direction */
+  trend?: TrendDirection;
+  /** Optional trend description, e.g. "+12% from last month" */
+  trendLabel?: string;
+  className?: string;
+}
+
+const trendStyles: Record<TrendDirection, { arrow: string; color: string }> = {
+  up: {
+    arrow: "M13 7h8m0 0v8m0-8l-8 8-4-4-6 6",
+    color: "text-emerald-600 bg-emerald-50",
+  },
+  down: {
+    arrow: "M13 17h8m0 0V9m0 8l-8-8-4 4-6-6",
+    color: "text-red-600 bg-red-50",
+  },
+  neutral: {
+    arrow: "M5 12h14",
+    color: "text-slate-500 bg-slate-100",
+  },
+};
+
+export function StatCard({
+  icon,
+  iconClass = "bg-slate-100 text-slate-600",
+  label,
+  value,
+  trend,
+  trendLabel,
+  className,
+}: StatCardProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          className={cn(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg",
+            iconClass,
+          )}
+        >
+          {icon}
+        </div>
+        {trend && (
+          <span
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+              trendStyles[trend].color,
+            )}
+            aria-label={trendLabel ?? `${trend} trend`}
+          >
+            <svg
+              className="h-3 w-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2.5}
+            >
+              <path d={trendStyles[trend].arrow} />
+            </svg>
+            {trendLabel && <span>{trendLabel}</span>}
+          </span>
+        )}
+      </div>
+      <div>
+        <p className="text-2xl font-bold tracking-tight text-slate-900">
+          {value}
+        </p>
+        <p className="mt-0.5 text-xs font-medium text-slate-500">{label}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/member-dashboard.tsx
+++ b/src/components/organisms/member-dashboard.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import Link from "next/link";
+import { StatCard } from "@/components/molecules/stat-card";
+import {
+  DashboardShell,
+  DashboardSection,
+  DashboardStatRow,
+} from "@/components/templates/dashboard-shell";
+import { EventList } from "@/components/molecules/event-list";
+import type { AuthenticatedTenantBranding } from "@/components/molecules/authenticated-top-bar";
+import type {
+  DashboardStats,
+  ActivityItem,
+  UpcomingEvent,
+} from "@/lib/dashboard-queries";
+import { cn } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Inline SVG icons (matching the codebase stroke style)
+// ---------------------------------------------------------------------------
+
+function IconSvg({ children }: { children: React.ReactNode }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.75}
+    >
+      {children}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface MemberDashboardProps {
+  stats: DashboardStats;
+  recentActivity: ActivityItem[];
+  upcomingEvents: UpcomingEvent[];
+  tenantBranding?: AuthenticatedTenantBranding;
+}
+
+// ---------------------------------------------------------------------------
+// Activity feed (read-only timeline)
+// ---------------------------------------------------------------------------
+
+function ActivityFeed({ items }: { items: ActivityItem[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">No recent activity to show.</p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-slate-100">
+      {items.map((item) => {
+        const time = new Date(item.timestamp);
+        const timeAgo = formatTimeAgo(time);
+
+        return (
+          <li key={`${item.kind}-${item.id}`} className="flex gap-3 py-3 first:pt-0 last:pb-0">
+            <span
+              className={cn(
+                "mt-0.5 flex h-2 w-2 shrink-0 rounded-full",
+                item.kind === "announcement"
+                  ? "bg-blue-500"
+                  : item.kind === "event"
+                    ? "bg-emerald-500"
+                    : "bg-slate-400",
+              )}
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium text-slate-800">
+                  {item.title}
+                </span>
+                {item.category && (
+                  <span className="shrink-0 rounded-full border border-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    {item.category}
+                  </span>
+                )}
+              </div>
+              {item.description && (
+                <p className="mt-0.5 line-clamp-2 text-xs text-slate-500">
+                  {item.description}
+                </p>
+              )}
+              <p className="mt-1 text-[10px] font-medium uppercase tracking-wider text-slate-400">
+                {timeAgo}
+              </p>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quick Actions bar
+// ---------------------------------------------------------------------------
+
+function QuickActions() {
+  const actions = [
+    {
+      label: "My ID Card",
+      href: "/member/id",
+      active: true,
+      icon: (
+        <IconSvg>
+          <path d="M4 7a2 2 0 012-2h12a2 2 0 012 2v10a2 2 0 01-2 2H6a2 2 0 01-2-2V7z" />
+          <path d="M8 11h3m-3 4h8M9.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "View Events",
+      href: "/member/events",
+      active: true,
+      icon: (
+        <IconSvg>
+          <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "View Documents",
+      href: "/member/documents",
+      active: true,
+      icon: (
+        <IconSvg>
+          <path d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+        </IconSvg>
+      ),
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {actions.map((action) =>
+        action.active ? (
+          <Link
+            key={action.label}
+            href={action.href}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 hover:border-slate-300"
+          >
+            {action.icon}
+            {action.label}
+          </Link>
+        ) : (
+          <button
+            key={action.label}
+            type="button"
+            disabled
+            className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-slate-100 bg-slate-50 px-4 py-2.5 text-sm font-medium text-slate-400"
+            title="Coming soon"
+          >
+            {action.icon}
+            {action.label}
+          </button>
+        ),
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Time formatting helper
+// ---------------------------------------------------------------------------
+
+function formatTimeAgo(date: Date): string {
+  const now = Date.now();
+  const diff = now - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function MemberDashboard({
+  stats,
+  recentActivity,
+  upcomingEvents,
+  tenantBranding,
+}: MemberDashboardProps) {
+  return (
+    <DashboardShell>
+      {/* Stat cards row — full width */}
+      <DashboardStatRow>
+        <StatCard
+          label="Organization Members"
+          value={stats.memberCount}
+          icon={
+            <IconSvg>
+              <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </IconSvg>
+          }
+          iconClass="bg-blue-50 text-blue-600"
+        />
+        <StatCard
+          label="Upcoming Events"
+          value={stats.eventCount}
+          icon={
+            <IconSvg>
+              <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </IconSvg>
+          }
+          iconClass="bg-emerald-50 text-emerald-600"
+        />
+        <StatCard
+          label="Announcements"
+          value={stats.announcementCount}
+          icon={
+            <IconSvg>
+              <path d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+            </IconSvg>
+          }
+          iconClass="bg-amber-50 text-amber-600"
+        />
+        <StatCard
+          label="Pending Applications"
+          value={stats.pendingApplicantCount}
+          icon={
+            <IconSvg>
+              <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </IconSvg>
+          }
+          iconClass="bg-purple-50 text-purple-600"
+        />
+      </DashboardStatRow>
+
+      {/* Upcoming Events + Activity Feed */}
+      <DashboardSection title="Upcoming Events">
+        <EventList
+          events={upcomingEvents}
+          tenant={tenantBranding ?? { name: "Organization", primaryColor: "#c6623e", textColor: "#ffffff" }}
+          onEventClick={() => {}}
+        />
+      </DashboardSection>
+
+      <DashboardSection title="Recent Activity">
+        <ActivityFeed items={recentActivity} />
+      </DashboardSection>
+
+      {/* Quick Actions */}
+      <DashboardSection title="Quick Actions" fullWidth>
+        <QuickActions />
+      </DashboardSection>
+    </DashboardShell>
+  );
+}

--- a/src/components/organisms/officer-dashboard.tsx
+++ b/src/components/organisms/officer-dashboard.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import Link from "next/link";
+import { StatCard } from "@/components/molecules/stat-card";
+import {
+  DashboardShell,
+  DashboardSection,
+  DashboardStatRow,
+} from "@/components/templates/dashboard-shell";
+import { EventList } from "@/components/molecules/event-list";
+import { StatusBadge } from "@/components/atoms/status-badge";
+import type { AuthenticatedTenantBranding } from "@/components/molecules/authenticated-top-bar";
+import type {
+  DashboardStats,
+  ActivityItem,
+  UpcomingEvent,
+  MemberSummary,
+} from "@/lib/dashboard-queries";
+
+// ---------------------------------------------------------------------------
+// Inline SVG icons
+// ---------------------------------------------------------------------------
+
+function IconSvg({ children }: { children: React.ReactNode }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.75}
+    >
+      {children}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface OfficerDashboardProps {
+  stats: DashboardStats;
+  recentActivity: ActivityItem[];
+  upcomingEvents: UpcomingEvent[];
+  memberSummary: MemberSummary;
+  tenantBranding?: AuthenticatedTenantBranding;
+  customPermissions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Member Roster Summary (status/dues breakdown)
+// ---------------------------------------------------------------------------
+
+function MemberRosterSummary({ summary }: { summary: MemberSummary }) {
+  const statusEntries = Object.entries(summary.byStatus).sort(
+    ([, a], [, b]) => b - a,
+  );
+  const duesEntries = Object.entries(summary.byDues).sort(
+    ([, a], [, b]) => b - a,
+  );
+
+  const maxStatus = Math.max(...Object.values(summary.byStatus), 1);
+  const maxDues = Math.max(...Object.values(summary.byDues), 1);
+
+  const statusVariant = (status: string): "green" | "yellow" | "red" => {
+    switch (status) {
+      case "Active":
+        return "green";
+      case "Probation":
+        return "yellow";
+      case "Suspended":
+        return "red";
+      default:
+        return "yellow";
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+            By Status
+          </span>
+          <span className="text-sm font-bold text-slate-800">
+            {summary.total}
+          </span>
+        </div>
+        <div className="space-y-2">
+          {statusEntries.map(([status, count]) => (
+            <div key={status} className="flex items-center gap-3">
+              <StatusBadge variant={statusVariant(status)}>
+                {status}
+              </StatusBadge>
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-slate-700 transition-all"
+                  style={{ width: `${(count / maxStatus) * 100}%` }}
+                />
+              </div>
+              <span className="text-sm font-medium tabular-nums text-slate-600">
+                {count}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+            By Dues
+          </span>
+        </div>
+        <div className="space-y-2">
+          {duesEntries.map(([dues, count]) => (
+            <div key={dues} className="flex items-center gap-3">
+              <StatusBadge
+                variant={dues === "Paid" ? "green" : "red"}
+              >
+                {dues}
+              </StatusBadge>
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-slate-700 transition-all"
+                  style={{ width: `${(count / maxDues) * 100}%` }}
+                />
+              </div>
+              <span className="text-sm font-medium tabular-nums text-slate-600">
+                {count}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Activity feed
+// ---------------------------------------------------------------------------
+
+function formatTimeAgo(date: Date): string {
+  const now = Date.now();
+  const diff = now - date.getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function ActivityFeed({ items }: { items: ActivityItem[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-slate-500">No recent activity to show.</p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-slate-100">
+      {items.map((item) => {
+        const time = new Date(item.timestamp);
+        const timeAgo = formatTimeAgo(time);
+
+        return (
+          <li
+            key={`${item.kind}-${item.id}`}
+            className="flex gap-3 py-3 first:pt-0 last:pb-0"
+          >
+            <span
+              className={
+                "mt-0.5 flex h-2 w-2 shrink-0 rounded-full " +
+                (item.kind === "announcement"
+                  ? "bg-blue-500"
+                  : item.kind === "event"
+                    ? "bg-emerald-500"
+                    : "bg-slate-400")
+              }
+            />
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="truncate text-sm font-medium text-slate-800">
+                  {item.title}
+                </span>
+                {item.category && (
+                  <span className="shrink-0 rounded-full border border-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
+                    {item.category}
+                  </span>
+                )}
+              </div>
+              {item.description && (
+                <p className="mt-0.5 line-clamp-2 text-xs text-slate-500">
+                  {item.description}
+                </p>
+              )}
+              <p className="mt-1 text-[10px] font-medium uppercase tracking-wider text-slate-400">
+                {timeAgo}
+              </p>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quick Actions (conditionally gated by permissions)
+// ---------------------------------------------------------------------------
+
+function OfficerQuickActions({
+  canManageEvents,
+  canManageAnnouncements,
+  canManageRecruitment,
+}: {
+  canManageEvents: boolean;
+  canManageAnnouncements: boolean;
+  canManageRecruitment: boolean;
+}) {
+  const actions = [
+    {
+      label: "Create Event",
+      href: "/officer/events",
+      active: canManageEvents,
+      icon: (
+        <IconSvg>
+          <path d="M12 4v16m8-8H4" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "Post Announcement",
+      href: "/officer/feed",
+      active: canManageAnnouncements,
+      icon: (
+        <IconSvg>
+          <path d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "Take Attendance",
+      href: "/officer/attendance",
+      active: canManageEvents,
+      icon: (
+        <IconSvg>
+          <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2zm4-5l2 2 4-4" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "Manage Recruitment",
+      href: "/officer/recruitment",
+      active: canManageRecruitment,
+      icon: (
+        <IconSvg>
+          <path d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+        </IconSvg>
+      ),
+    },
+    {
+      label: "View Roster",
+      href: "/officer/members",
+      active: true,
+      icon: (
+        <IconSvg>
+          <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+        </IconSvg>
+      ),
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {actions.map((action) =>
+        action.active ? (
+          <Link
+            key={action.label}
+            href={action.href}
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 hover:border-slate-300"
+          >
+            {action.icon}
+            {action.label}
+          </Link>
+        ) : (
+          <button
+            key={action.label}
+            type="button"
+            disabled
+            className="inline-flex cursor-not-allowed items-center gap-2 rounded-lg border border-slate-100 bg-slate-50 px-4 py-2.5 text-sm font-medium text-slate-400"
+            title="You do not have permission to access this feature"
+          >
+            {action.icon}
+            {action.label}
+          </button>
+        ),
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OfficerDashboard({
+  stats,
+  recentActivity,
+  upcomingEvents,
+  memberSummary,
+  tenantBranding,
+  customPermissions = [],
+}: OfficerDashboardProps) {
+  const canManageEvents = customPermissions.includes("Event management");
+  const canManageAnnouncements = customPermissions.includes(
+    "Announcement management",
+  );
+  const canManageRecruitment = customPermissions.includes("Recruitment reviews");
+
+  const activeMemberCount =
+    memberSummary.byStatus["Active"] ?? 0;
+  const probCount = memberSummary.byStatus["Probation"] ?? 0;
+
+  return (
+    <DashboardShell>
+      {/* Stat cards row — full width */}
+      <DashboardStatRow>
+        <StatCard
+          label="Total Members"
+          value={memberSummary.total}
+          trend={probCount > 0 ? "down" : "neutral"}
+          trendLabel={probCount > 0 ? `${probCount} probation` : undefined}
+          icon={
+            <IconSvg>
+              <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            </IconSvg>
+          }
+          iconClass="bg-blue-50 text-blue-600"
+        />
+        <StatCard
+          label="Upcoming Events"
+          value={stats.eventCount}
+          icon={
+            <IconSvg>
+              <path d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </IconSvg>
+          }
+          iconClass="bg-emerald-50 text-emerald-600"
+        />
+        <StatCard
+          label="Pending Applicants"
+          value={stats.pendingApplicantCount}
+          icon={
+            <IconSvg>
+              <path d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </IconSvg>
+          }
+          iconClass="bg-purple-50 text-purple-600"
+        />
+        <StatCard
+          label="Active Announcements"
+          value={stats.announcementCount}
+          icon={
+            <IconSvg>
+              <path d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+            </IconSvg>
+          }
+          iconClass="bg-amber-50 text-amber-600"
+        />
+        <StatCard
+          label="Active Members"
+          value={activeMemberCount}
+          trend={
+            activeMemberCount < memberSummary.total ? "down" : "neutral"
+          }
+          icon={
+            <IconSvg>
+              <path d="M5 13l4 4L19 7" />
+            </IconSvg>
+          }
+          iconClass="bg-green-50 text-green-600"
+        />
+      </DashboardStatRow>
+
+      {/* Upcoming Events + Member Roster Summary */}
+      <DashboardSection title="Upcoming Events">
+        <EventList
+          canManage={canManageEvents}
+          events={upcomingEvents}
+          tenant={
+            tenantBranding ?? {
+              name: "Organization",
+              primaryColor: "#c6623e",
+              textColor: "#ffffff",
+            }
+          }
+          onEventClick={() => {}}
+        />
+      </DashboardSection>
+
+      <DashboardSection title="Member Roster Summary">
+        <MemberRosterSummary summary={memberSummary} />
+      </DashboardSection>
+
+      {/* Recent Activity */}
+      <DashboardSection title="Recent Activity" fullWidth>
+        <ActivityFeed items={recentActivity} />
+      </DashboardSection>
+
+      {/* Quick Actions */}
+      <DashboardSection title="Quick Actions" fullWidth>
+        <OfficerQuickActions
+          canManageEvents={canManageEvents}
+          canManageAnnouncements={canManageAnnouncements}
+          canManageRecruitment={canManageRecruitment}
+        />
+      </DashboardSection>
+    </DashboardShell>
+  );
+}

--- a/src/components/templates/dashboard-shell.tsx
+++ b/src/components/templates/dashboard-shell.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ScrollReveal } from "@/components/atoms/scroll-reveal";
+import { cn } from "@/lib/utils";
+
+interface DashboardShellProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Responsive bento-style grid layout for dashboards.
+ * 2-column on large screens, 1-column stacked on mobile.
+ * Each child gets a scroll-reveal animation applied.
+ */
+export function DashboardShell({ children, className }: DashboardShellProps) {
+  return (
+    <div
+      className={cn(
+        "grid grid-cols-1 gap-6 lg:grid-cols-2",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface DashboardSectionProps {
+  children: ReactNode;
+  title?: string;
+  /** Makes this section span full width in the 2-col grid */
+  fullWidth?: boolean;
+  className?: string;
+  delay?: number;
+}
+
+/**
+ * A single dashboard card section with optional title.
+ * Wraps children in a white card with border and shadow,
+ * and applies a scroll-reveal animation on mount.
+ */
+export function DashboardSection({
+  children,
+  title,
+  fullWidth = false,
+  className,
+  delay = 0,
+}: DashboardSectionProps) {
+  return (
+    <ScrollReveal delay={delay} className={fullWidth ? "lg:col-span-2" : undefined}>
+      <div
+        className={cn(
+          "rounded-xl border border-slate-200 bg-white p-6 shadow-sm",
+          className,
+        )}
+      >
+        {title && (
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-[0.15em] text-slate-500">
+            {title}
+          </h2>
+        )}
+        {children}
+      </div>
+    </ScrollReveal>
+  );
+}
+
+interface DashboardStatRowProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * A row of stat cards that spans the full width.
+ * Uses CSS grid for responsive stat card layout.
+ */
+export function DashboardStatRow({ children, className }: DashboardStatRowProps) {
+  return (
+    <ScrollReveal delay={0} className="lg:col-span-2">
+      <div
+        className={cn(
+          "grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </ScrollReveal>
+  );
+}

--- a/src/lib/dashboard-queries.ts
+++ b/src/lib/dashboard-queries.ts
@@ -1,0 +1,258 @@
+import { cache } from "react";
+import {
+  createSupabaseUserClient,
+  resolveCurrentTenant,
+  getCurrentViewer,
+} from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DashboardStats {
+  memberCount: number;
+  eventCount: number;
+  announcementCount: number;
+  pendingApplicantCount: number;
+}
+
+export interface ActivityItem {
+  kind: "announcement" | "event" | "audit";
+  id: string;
+  title: string;
+  description?: string;
+  timestamp: string;
+  category?: string;
+}
+
+export interface UpcomingEvent {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  start_time: string;
+  end_time: string;
+  date: string;
+  month: string;
+  day: number;
+  time: string;
+  type: string;
+  status: string;
+}
+
+export interface MemberSummary {
+  total: number;
+  byStatus: Record<string, number>;
+  byDues: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function monthLabel(date: Date): string {
+  return date.toLocaleString("en-US", { month: "short" });
+}
+
+// ---------------------------------------------------------------------------
+// Query functions (all cached via React cache())
+// ---------------------------------------------------------------------------
+
+export const getDashboardStats = cache(
+  async (/* tenantId is extracted internally */): Promise<DashboardStats> => {
+    const { tenant } = await resolveCurrentTenant();
+    const userClient = await createSupabaseUserClient();
+
+    if (!tenant || !userClient) {
+      return {
+        memberCount: 0,
+        eventCount: 0,
+        announcementCount: 0,
+        pendingApplicantCount: 0,
+      };
+    }
+
+    const [memberResult, eventResult, announcementResult, applicantResult] =
+      await Promise.all([
+        userClient
+          .from("organization_memberships")
+          .select("id", { count: "exact", head: true })
+          .eq("tenant_id", tenant.id),
+
+        userClient
+          .from("events")
+          .select("id", { count: "exact", head: true })
+          .eq("tenant_id", tenant.id),
+
+        userClient
+          .from("announcements")
+          .select("id", { count: "exact", head: true })
+          .eq("tenant_id", tenant.id),
+
+        userClient
+          .from("temporary_applicants")
+          .select("id", { count: "exact", head: true })
+          .eq("tenant_id", tenant.id)
+          .eq("status", "submitted"),
+      ]);
+
+    return {
+      memberCount: memberResult.count ?? 0,
+      eventCount: eventResult.count ?? 0,
+      announcementCount: announcementResult.count ?? 0,
+      pendingApplicantCount: applicantResult.count ?? 0,
+    };
+  },
+);
+
+export const getRecentActivity = cache(
+  async (
+    tenantId: string,
+    limit = 8,
+  ): Promise<ActivityItem[]> => {
+    const userClient = await createSupabaseUserClient();
+    if (!userClient) return [];
+
+    const [announcementResult, eventResult] = await Promise.all([
+      userClient
+        .from("announcements")
+        .select("id, title, body, created_at, category")
+        .eq("tenant_id", tenantId)
+        .order("created_at", { ascending: false })
+        .limit(limit),
+
+      userClient
+        .from("events")
+        .select("id, title, description, start_time")
+        .eq("tenant_id", tenantId)
+        .order("created_at", { ascending: false })
+        .limit(limit),
+    ]);
+
+    const items: ActivityItem[] = [];
+
+    for (const a of announcementResult.data ?? []) {
+      items.push({
+        kind: "announcement",
+        id: a.id,
+        title: a.title,
+        description: a.body?.slice(0, 120) ?? undefined,
+        timestamp: a.created_at,
+        category: a.category ?? undefined,
+      });
+    }
+
+    for (const e of eventResult.data ?? []) {
+      items.push({
+        kind: "event",
+        id: e.id,
+        title: e.title,
+        description: e.description?.slice(0, 120) ?? undefined,
+        timestamp: e.start_time,
+      });
+    }
+
+    // Sort merged list by timestamp descending
+    items.sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
+
+    return items.slice(0, limit);
+  },
+);
+
+export const getUpcomingEvents = cache(
+  async (
+    tenantId: string,
+    limit = 4,
+  ): Promise<UpcomingEvent[]> => {
+    const userClient = await createSupabaseUserClient();
+    if (!userClient) return [];
+
+    const now = new Date().toISOString();
+
+    const { data } = await userClient
+      .from("events")
+      .select("id, title, description, location, start_time, end_time")
+      .eq("tenant_id", tenantId)
+      .gte("start_time", now)
+      .order("start_time", { ascending: true })
+      .limit(limit);
+
+    return (data ?? []).map((event) => {
+      const start = new Date(event.start_time);
+      const timeStr = start.toLocaleTimeString("en-US", {
+        hour: "numeric",
+        minute: "2-digit",
+        hour12: true,
+      });
+      return {
+        id: event.id,
+        title: event.title,
+        description: event.description ?? "",
+        location: event.location ?? "TBD",
+        start_time: event.start_time,
+        end_time: event.end_time,
+        date: event.start_time,
+        month: monthLabel(start),
+        day: start.getDate(),
+        time: timeStr,
+        type: "Event",
+        status: "upcoming",
+      };
+    });
+  },
+);
+
+export const getMemberSummary = cache(
+  async (): Promise<MemberSummary> => {
+    const { tenant } = await resolveCurrentTenant();
+    const viewer = await getCurrentViewer();
+    const adminClient = createSupabaseAdminClient("getMemberSummary");
+
+    if (!tenant || !viewer || !adminClient) {
+      return { total: 0, byStatus: {}, byDues: {} };
+    }
+
+    const { data } = await adminClient
+      .from("organization_memberships")
+      .select("membership_status, dues_status")
+      .eq("tenant_id", tenant.id);
+
+    const members = data ?? [];
+    const byStatus: Record<string, number> = {};
+    const byDues: Record<string, number> = {};
+
+    for (const m of members) {
+      const status = m.membership_status ?? "Active";
+      byStatus[status] = (byStatus[status] ?? 0) + 1;
+
+      const dues = m.dues_status ?? "Unpaid";
+      byDues[dues] = (byDues[dues] ?? 0) + 1;
+    }
+
+    return { total: members.length, byStatus, byDues };
+  },
+);
+
+/**
+ * Returns the number of memberships for the current tenant, scoped to the
+ * given status filter. Primarily used for stat cards.
+ */
+export const getMemberCountByStatus = cache(
+  async (status: string): Promise<number> => {
+    const { tenant } = await resolveCurrentTenant();
+    const userClient = await createSupabaseUserClient();
+    if (!tenant || !userClient) return 0;
+
+    const { count } = await userClient
+      .from("organization_memberships")
+      .select("id", { count: "exact", head: true })
+      .eq("tenant_id", tenant.id)
+      .eq("membership_status", status);
+
+    return count ?? 0;
+  },
+);

--- a/src/lib/navigation-config.tsx
+++ b/src/lib/navigation-config.tsx
@@ -288,8 +288,9 @@ const ROLE_ROUTE_SLUGS: Record<UserRole, RouteSlug[]> = {
     "settings",
     "documents",
   ],
-  Officer: ["feed", "members", "documents"],
+  Officer: ["dashboard", "feed", "members", "documents"],
   Member: [
+    "dashboard",
     "feed",
     "members",
     "applications",

--- a/src/lib/organization-permissions.ts
+++ b/src/lib/organization-permissions.ts
@@ -1,7 +1,6 @@
 import type { ViewerContext } from "@/lib/supabase/server";
 
 export const AVAILABLE_PERMISSIONS = [
-  "Dashboard access",
   "Member roster edits",
   "Recruitment reviews",
   "Event management",


### PR DESCRIPTION
### What Each Dashboard Shows

**Member Dashboard:**
- 4 stat cards (Org Members, Upcoming Events, Announcements, Pending Applications)
- Upcoming Events list (reuses existing `EventList` molecule)
- Recent Activity feed (merged announcements + events timeline)
- Quick Actions bar (My ID Card, View Events, View Documents)

**Officer Dashboard:**
- 5 stat cards (Total Members, Upcoming Events, Pending Applicants, Announcements, Active Members with probation trend)
- Upcoming Events list (with manage buttons if permitted)
- Member Roster Summary (status/dues breakdown with colored bars)
- Recent Activity feed (full width)
- Quick Actions bar (Create Event, Post Announcement, Take Attendance, Manage Recruitment, View Roster) — gated by custom permissions